### PR TITLE
 [FEATURE] 장바구니에 도서 정보를 등록하는 로직 구현

### DIFF
--- a/src/main/java/com/jamjam/bookjeok/domains/order/controller/cart/CartController.java
+++ b/src/main/java/com/jamjam/bookjeok/domains/order/controller/cart/CartController.java
@@ -1,0 +1,31 @@
+package com.jamjam.bookjeok.domains.order.controller.cart;
+
+import com.jamjam.bookjeok.common.dto.ApiResponse;
+import com.jamjam.bookjeok.domains.order.dto.cart.response.CartResponse;
+import com.jamjam.bookjeok.domains.order.dto.cart.request.CartRequest;
+import com.jamjam.bookjeok.domains.order.service.cart.CartService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/v1")
+@RequiredArgsConstructor
+public class CartController {
+
+    private final CartService cartService;
+
+    @PostMapping("/cart")
+    public ResponseEntity<ApiResponse<CartResponse>> createBookToCart(
+            @RequestBody @Validated CartRequest cartRequest
+    ) {
+        CartResponse cartResponse = cartService.createBookToCart(cartRequest);
+
+        return ResponseEntity
+                .status(HttpStatus.CREATED)
+                .body(ApiResponse.success(cartResponse));
+    }
+
+}

--- a/src/main/java/com/jamjam/bookjeok/domains/order/dto/cart/request/CartRequest.java
+++ b/src/main/java/com/jamjam/bookjeok/domains/order/dto/cart/request/CartRequest.java
@@ -1,0 +1,16 @@
+package com.jamjam.bookjeok.domains.order.dto.cart.request;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
+
+@Builder
+public record CartRequest(
+        @NotNull(message = "memberUid는 비어있을 수 없습니다.") Long memberUid,
+        @NotNull(message = "bookId는 비어있을 수 없습니다.") Long bookId,
+        @NotBlank(message = "책 이름은 비어있을 수 없습니다.") String bookName,
+        @Min(value = 1, message = "책의 가격은 0보다 작을 수 없습니다.") int price,
+        @Min(value = 1, message = "책의 수량은 1개 보다 작을 수 없습니다.") int quantity
+) {
+}

--- a/src/main/java/com/jamjam/bookjeok/domains/order/dto/cart/response/CartResponse.java
+++ b/src/main/java/com/jamjam/bookjeok/domains/order/dto/cart/response/CartResponse.java
@@ -1,0 +1,9 @@
+package com.jamjam.bookjeok.domains.order.dto.cart.response;
+
+import lombok.Builder;
+
+@Builder
+public record CartResponse(
+        Long memberUid, Long bookId, String bookName, int totalPrice, int quantity
+) {
+}

--- a/src/main/java/com/jamjam/bookjeok/domains/order/entity/Cart.java
+++ b/src/main/java/com/jamjam/bookjeok/domains/order/entity/Cart.java
@@ -1,5 +1,6 @@
 package com.jamjam.bookjeok.domains.order.entity;
 
+import com.jamjam.bookjeok.exception.order.cart.CartItemLimitExceededException;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -43,6 +44,22 @@ public class Cart {
         this.quantity = quantity;
         this.createdAt = createdAt;
         this.modifiedAt = modifiedAt;
+    }
+
+    public static void validateCartItemLimit(final int cartItemCountFromDb) {
+        final int MAX_CART_COUNT = 20;
+
+        if (cartItemCountFromDb >= MAX_CART_COUNT) {
+            throw new CartItemLimitExceededException("장바구니에는 최대 20까지 도서를 담을 수 있습니다.");
+        }
+    }
+
+    public static int calculateBookTotalPrice(final int quantity, final int price) {
+        return quantity * price;
+    }
+
+    public void addQuantity(final int quantity) {
+        this.quantity += quantity;
     }
 
 }

--- a/src/main/java/com/jamjam/bookjeok/domains/order/repository/cart/CartRepository.java
+++ b/src/main/java/com/jamjam/bookjeok/domains/order/repository/cart/CartRepository.java
@@ -1,0 +1,8 @@
+package com.jamjam.bookjeok.domains.order.repository.cart;
+
+import com.jamjam.bookjeok.domains.order.entity.Cart;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CartRepository extends JpaRepository<Cart, Long> {
+
+}

--- a/src/main/java/com/jamjam/bookjeok/domains/order/repository/cart/mapper/CartMapper.java
+++ b/src/main/java/com/jamjam/bookjeok/domains/order/repository/cart/mapper/CartMapper.java
@@ -1,0 +1,21 @@
+package com.jamjam.bookjeok.domains.order.repository.cart.mapper;
+
+import com.jamjam.bookjeok.domains.book.entity.Book;
+import com.jamjam.bookjeok.domains.member.entity.Member;
+import com.jamjam.bookjeok.domains.order.entity.Cart;
+import org.apache.ibatis.annotations.Mapper;
+
+import java.util.Optional;
+
+@Mapper
+public interface CartMapper {
+
+    Optional<Member> findMemberById(Long memberUid);
+
+    Optional<Book> findBookByIdAndBookNameAndPrice(Long bookId, String bookName, int price);
+
+    int findCartCountByMemberUid(Long memberUid);
+
+    Optional<Cart> findCartByMemberUidAndBookId(Long memberUid, Long bookId);
+
+}

--- a/src/main/java/com/jamjam/bookjeok/domains/order/service/cart/CartService.java
+++ b/src/main/java/com/jamjam/bookjeok/domains/order/service/cart/CartService.java
@@ -1,0 +1,10 @@
+package com.jamjam.bookjeok.domains.order.service.cart;
+
+import com.jamjam.bookjeok.domains.order.dto.cart.response.CartResponse;
+import com.jamjam.bookjeok.domains.order.dto.cart.request.CartRequest;
+
+public interface CartService {
+
+    CartResponse createBookToCart(CartRequest cartRequest);
+
+}

--- a/src/main/java/com/jamjam/bookjeok/exception/order/cart/CartExceptionHandler.java
+++ b/src/main/java/com/jamjam/bookjeok/exception/order/cart/CartExceptionHandler.java
@@ -1,0 +1,33 @@
+package com.jamjam.bookjeok.exception.order.cart;
+
+import com.jamjam.bookjeok.common.dto.ApiResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class CartExceptionHandler {
+
+    @ExceptionHandler(CartItemLimitExceededException.class)
+    public ResponseEntity<ApiResponse<Void>> cartItemLimitExceededExceptionHandler(CartItemLimitExceededException e) {
+        String errorCode = HttpStatus.BAD_REQUEST.getReasonPhrase();
+        String errorMessage = e.getMessage();
+
+        return ResponseEntity
+                .badRequest()
+                .body(ApiResponse.failure(errorCode, errorMessage));
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ApiResponse<Void>> methodArgumentNotValidExceptionHandler(MethodArgumentNotValidException e) {
+        String errorCode = HttpStatus.BAD_REQUEST.getReasonPhrase();
+        String errorMessage = e.getBindingResult().getAllErrors().get(0).getDefaultMessage();
+
+        return ResponseEntity
+                .badRequest()
+                .body(ApiResponse.failure(errorCode, errorMessage));
+    }
+
+}

--- a/src/main/java/com/jamjam/bookjeok/exception/order/cart/CartItemLimitExceededException.java
+++ b/src/main/java/com/jamjam/bookjeok/exception/order/cart/CartItemLimitExceededException.java
@@ -1,0 +1,9 @@
+package com.jamjam.bookjeok.exception.order.cart;
+
+public class CartItemLimitExceededException extends RuntimeException {
+
+    public CartItemLimitExceededException(String message) {
+        super(message);
+    }
+
+}

--- a/src/main/resources/mappers/domain/order/CartMapper.xml
+++ b/src/main/resources/mappers/domain/order/CartMapper.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "https://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="com.jamjam.bookjeok.domains.order.repository.cart.mapper.CartMapper">
+    <select id="findMemberById" resultType="com.jamjam.bookjeok.domains.member.entity.Member">
+        SELECT
+            member_uid, member_id, password,
+            member_name, phone_number, email,
+            nickname, birth_date, marketing_consent,
+            role, created_at, modified_at, activity_status
+        FROM members
+        WHERE member_uid = #{ memberUid }
+    </select>
+
+    <select id="findBookByIdAndBookNameAndPrice" resultType="com.jamjam.bookjeok.domains.book.entity.Book">
+        SELECT
+            book_id, publisher_id, category_id,
+            book_name, isbn, image_url, published_at,
+            price, stock_quantity, created_at, modified_at, is_deleted
+        FROM books
+        WHERE book_id = #{ bookId }
+        AND book_name = #{ bookName }
+        AND price = #{ price }
+    </select>
+
+    <select id="findCartCountByMemberUid" resultType="int">
+        SELECT COUNT(*)
+        FROM carts
+        WHERE member_uid = #{ memberUid }
+    </select>
+
+    <select id="findCartByMemberUidAndBookId" resultType="com.jamjam.bookjeok.domains.order.entity.Cart">
+        SELECT
+            cart_id, member_uid, book_id,
+            quantity, created_at, modified_at
+        FROM carts
+        WHERE member_uid = #{ memberUid }
+        AND book_id = #{ bookId }
+    </select>
+</mapper>

--- a/src/test/java/com/jamjam/bookjeok/BookjeokApplicationTests.java
+++ b/src/test/java/com/jamjam/bookjeok/BookjeokApplicationTests.java
@@ -2,8 +2,10 @@ package com.jamjam.bookjeok;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
+@ActiveProfiles("test")
 class BookjeokApplicationTests {
 
 	@Test

--- a/src/test/java/com/jamjam/bookjeok/domains/order/controller/cart/CartControllerTest.java
+++ b/src/test/java/com/jamjam/bookjeok/domains/order/controller/cart/CartControllerTest.java
@@ -1,0 +1,83 @@
+package com.jamjam.bookjeok.domains.order.controller.cart;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.jamjam.bookjeok.domains.order.dto.cart.request.CartRequest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@Transactional
+@SpringBootTest
+@ActiveProfiles("test")
+@AutoConfigureMockMvc
+class CartControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Test
+    @DisplayName("장바구니에 도서를 등록하는 테스트")
+    void testCreateBookToCart() throws Exception {
+        CartRequest cartRequest = CartRequest.builder()
+                .memberUid(1L)
+                .bookId(2L)
+                .bookName("채식주의자")
+                .price(13000)
+                .quantity(10)
+                .build();
+
+        mockMvc.perform(post("/api/v1/cart")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .accept(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(cartRequest))
+                ).andDo(print())
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.memberUid").exists())
+                .andExpect(jsonPath("$.data.memberUid").value(1L))
+                .andExpect(jsonPath("$.data.bookId").exists())
+                .andExpect(jsonPath("$.data.bookId").value(2L))
+                .andExpect(jsonPath("$.data.bookName").value("채식주의자"))
+                .andExpect(jsonPath("$.data.totalPrice").value(130000))
+                .andExpect(jsonPath("$.data.quantity").value(10))
+                .andExpect(jsonPath("$.timestamp").exists())
+                .andExpect(jsonPath("$.message").doesNotExist())
+                .andExpect(header().string(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE));
+    }
+
+    @Test
+    @DisplayName("장바구니에 도서를 등록할 때 필요한 정보[책 이름]가 없으면 예외가 발생하는 테스트")
+    void testCreateBookToCartException() throws Exception {
+        CartRequest cartRequest = CartRequest.builder()
+                .memberUid(1L)
+                .bookId(2L)
+                .price(13000)
+                .quantity(10)
+                .build();
+
+        mockMvc.perform(post("/api/v1/cart")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .accept(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(cartRequest))
+                ).andDo(print())
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.message").value("책 이름은 비어있을 수 없습니다."))
+                .andExpect(header().string(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE));
+    }
+
+}

--- a/src/test/java/com/jamjam/bookjeok/domains/order/entity/CartTest.java
+++ b/src/test/java/com/jamjam/bookjeok/domains/order/entity/CartTest.java
@@ -1,0 +1,67 @@
+package com.jamjam.bookjeok.domains.order.entity;
+
+import com.jamjam.bookjeok.exception.order.cart.CartItemLimitExceededException;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.time.LocalDateTime;
+
+import static com.jamjam.bookjeok.domains.order.entity.Cart.calculateBookTotalPrice;
+import static com.jamjam.bookjeok.domains.order.entity.Cart.validateCartItemLimit;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+@SpringBootTest
+@ActiveProfiles("test")
+class CartTest {
+
+    @ParameterizedTest
+    @ValueSource(ints = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9})
+    @DisplayName("장바구니에 도서 정보가 20개 이하인 경우 통과하는 테스트")
+    void testValidateCartItemLimit(int condition) {
+        assertThatCode(() -> validateCartItemLimit(condition))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("장바구니에 20개가 넘는 도서 정보가 있으면 예외가 발생하는 테스트")
+    void testValidateCartItemLimitException() {
+        int cartCount = 20;
+
+        Assertions.assertThatThrownBy(() -> Cart.validateCartItemLimit(cartCount))
+                .isInstanceOf(CartItemLimitExceededException.class)
+                .hasMessage("장바구니에는 최대 20까지 도서를 담을 수 있습니다.");
+    }
+
+    @Test
+    @DisplayName("도서 수량, 가격으로 금액을 구하는 테스트")
+    void testCalculateBookTotalPrice() {
+        int quantity = 10;
+        int price = 35000;
+        int expectedValue = 350000;
+
+        int calculatedBookTotalPrice = calculateBookTotalPrice(quantity, price);
+
+        assertThat(calculatedBookTotalPrice).isEqualTo(expectedValue);
+    }
+
+    @Test
+    @DisplayName("장바구니에서 도서 수량을 추가하는 테스트")
+    void testAddQuantity() {
+        Cart cart = Cart.builder()
+                .memberUid(1L)
+                .bookId(1L)
+                .quantity(10)
+                .createdAt(LocalDateTime.now().withNano(0))
+                .build();
+        cart.addQuantity(20);
+
+        assertThat(cart.getQuantity()).isEqualTo(30);
+    }
+
+}

--- a/src/test/java/com/jamjam/bookjeok/domains/order/repository/cart/mapper/CartMapperTest.java
+++ b/src/test/java/com/jamjam/bookjeok/domains/order/repository/cart/mapper/CartMapperTest.java
@@ -1,0 +1,69 @@
+package com.jamjam.bookjeok.domains.order.repository.cart.mapper;
+
+import com.jamjam.bookjeok.domains.book.entity.Book;
+import com.jamjam.bookjeok.domains.member.entity.Member;
+import com.jamjam.bookjeok.domains.order.entity.Cart;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Transactional
+@SpringBootTest
+@ActiveProfiles("test")
+class CartMapperTest {
+
+    @Autowired
+    private CartMapper cartMapper;
+
+    @Test
+    @DisplayName("memberUid로 회원 정보를 찾는 테스트")
+    void testFindMemberById() {
+        Long memberUid = 1L;
+
+        Optional<Member> findMember = cartMapper.findMemberById(memberUid);
+
+        assertThat(findMember).isNotNull();
+        assertThat(findMember.get().getMemberUid()).isEqualTo(memberUid);
+    }
+
+    @Test
+    @DisplayName("bookId로 책 정보 찾는 테스트")
+    void testFindBookByIdAndBookNameAndPrice() {
+        Long bookId = 1L;
+        String bookName = "태백산맥 1권";
+        int price = 18000;
+
+        Optional<Book> findBook = cartMapper.findBookByIdAndBookNameAndPrice(bookId, bookName, price);
+
+        assertThat(findBook).isNotNull();
+        assertThat(findBook.get().getBookId()).isEqualTo(bookId);
+    }
+
+    @Test
+    @DisplayName("장바구니에서 도서 정보 개수를 조회하는 테스트")
+    void testFindCartCountByMemberUid() {
+        Long memberUid = 1L;
+
+        int count = cartMapper.findCartCountByMemberUid(memberUid);
+
+        assertThat(count).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("장바구니에서 memberUid와 bookId로 장바구니 정보 조회 ")
+    void testFindCartByMemberUidAndBookId() {
+        Cart cart = cartMapper.findCartByMemberUidAndBookId(1L, 1L).get();
+
+        assertThat(cart).isNotNull();
+        assertThat(cart.getMemberUid()).isEqualTo(1L);
+        assertThat(cart.getBookId()).isEqualTo(1L);
+    }
+
+}

--- a/src/test/java/com/jamjam/bookjeok/domains/order/service/cart/CartServiceImplTest.java
+++ b/src/test/java/com/jamjam/bookjeok/domains/order/service/cart/CartServiceImplTest.java
@@ -1,0 +1,72 @@
+package com.jamjam.bookjeok.domains.order.service.cart;
+
+import com.jamjam.bookjeok.domains.order.dto.cart.response.CartResponse;
+import com.jamjam.bookjeok.domains.order.dto.cart.request.CartRequest;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Slf4j
+@Transactional
+@SpringBootTest
+@ActiveProfiles("test")
+class CartServiceImplTest {
+
+    @Autowired
+    private CartService cartService;
+
+    @Test
+    @DisplayName("장바구니에 도서 정보 추가하는 테스트")
+    void testCreateBookToCart() {
+        CartRequest cartRequest = CartRequest.builder()
+                .memberUid(1L)
+                .bookId(2L)
+                .bookName("채식주의자")
+                .price(13000)
+                .quantity(10)
+                .build();
+
+        CartResponse cartResponse = cartService.createBookToCart(cartRequest);
+
+        log.info("cartResponse: {}", cartResponse.toString());
+
+        assertThat(cartResponse).isNotNull();
+
+        assertThat(cartResponse.memberUid()).isEqualTo(1L);
+        assertThat(cartResponse.bookId()).isEqualTo(2L);
+        assertThat(cartResponse.bookName()).isEqualTo("채식주의자");
+        assertThat(cartResponse.totalPrice()).isEqualTo(130000);
+        assertThat(cartResponse.quantity()).isEqualTo(10);
+    }
+
+    @Test
+    @DisplayName("장바구니에 도서 정보 추가할 때 동일한 책 정보가 있으면 수량을 증가시키는 테스트")
+    void testCreateBookToCartAddQuantity() {
+        CartRequest cartRequest = CartRequest.builder()
+                .memberUid(1L)
+                .bookId(1L)
+                .bookName("태백산맥 1권")
+                .price(18000)
+                .quantity(10)
+                .build();
+
+        CartResponse cartResponse = cartService.createBookToCart(cartRequest);
+
+        log.info("cartResponse: {}", cartResponse.toString());
+
+        assertThat(cartResponse).isNotNull();
+
+        assertThat(cartResponse.memberUid()).isEqualTo(1L);
+        assertThat(cartResponse.bookId()).isEqualTo(1L);
+        assertThat(cartResponse.bookName()).isEqualTo("태백산맥 1권");
+        assertThat(cartResponse.totalPrice()).isEqualTo(360000);
+        assertThat(cartResponse.quantity()).isEqualTo(20);
+    }
+
+}


### PR DESCRIPTION
- 클라이언트는 memberUid, bookId, bookName, price, quantity를 서버에 전달한다.
- 서버는 memberUid, bookId, bookName, price, quantity를 검증한다.
- 도서 정보가 서버에 저장된 정보와 일치하는지 확인한다.
- memberUid와 bookId를 사용하여 장바구니에 등록할 도서명이 이미 장바구니에 존재하는지 확인한다.
  - 동일한 도서명이 있다면, 일치하는 도서명에 클라이언트가 전달한 quantity를 기존 수량에 더한다.
  - 동일한 도서명이 없다면, 장바구니에 있는 도서 정보가 20개 이상인지 검증한다.
    - 검증이 완료되었으면 Cart 엔티티를 생성해서 데이터베이스에 저장한다.
- 도서 가격과 수량으로 결제 예정 금액을 구한다.
- Cart, Book, totalPrice를 사용하여 응답 객체를 생성하고 반환한다.