### PR TITLE
[FEATURE] 도서 API 연동 구현하기

### DIFF
--- a/src/main/java/com/jamjam/bookjeok/domains/book/contoller/BookApiController.java
+++ b/src/main/java/com/jamjam/bookjeok/domains/book/contoller/BookApiController.java
@@ -6,8 +6,12 @@ import com.jamjam.bookjeok.common.dto.ApiResponse;
 import com.jamjam.bookjeok.domains.book.dto.BookApiDTO;
 import com.jamjam.bookjeok.domains.book.dto.BookDTO;
 import com.jamjam.bookjeok.domains.book.dto.NaverResultDTO;
+import com.jamjam.bookjeok.domains.book.entity.Book;
+import com.jamjam.bookjeok.domains.book.entity.BookCategory;
+import com.jamjam.bookjeok.domains.book.entity.Publisher;
 import com.jamjam.bookjeok.domains.book.service.BookApiService;
-import com.jamjam.bookjeok.domains.book.service.BookCommandService;
+import com.jamjam.bookjeok.domains.book.service.BookAdminService;
+import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.RequestEntity;
@@ -20,31 +24,26 @@ import java.net.URI;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
 @RestController
 @RequestMapping("/api/v1")
+@RequiredArgsConstructor
 public class BookApiController {
 
-    private String clientId;
-    private String clientSecret;
-    private BookCommandService bookCommandService;
-    private BookApiService bookApiService;
+    private final BookAdminService bookAdminService;
+    private final BookApiService bookApiService;
 
-     public BookApiController (
-             @Value("${naver.book-client-api}") String clientId,
-             @Value("${naver.book-secret-key}") String clientSecret,
-             BookApiService bookApiService,
-             BookCommandService bookCommandService) {
-        this.clientId = clientId;
-        this.clientSecret = clientSecret;
-        this.bookApiService = bookApiService;
-        this.bookCommandService = bookCommandService;
-    }
+    @Value("${naver.book-client-api}")
+    private String clientId;
+
+    @Value("${naver.book-secret-key}")
+    private String clientKey;
+
+    @Value("${image.image-dir}")
+    private String filepath;
 
     @PostMapping("/bookApi/regist")
     public ResponseEntity<ApiResponse<Void>> registBook(@RequestParam(value = "keyword") String keyword) {
@@ -52,19 +51,13 @@ public class BookApiController {
         ResponseEntity<String> exchangeResponse = exchange(keyword);
 
         List<BookApiDTO> apiBooks = parseJson(exchangeResponse);
-
-        List<BookDTO> bookList = mapDto(apiBooks);
-
-        bookList.forEach(System.out::println);
-
-        /*for (BookDTO book : bookList) {
-           bookCommandService.registBook(book);
-        }*/
+        maptoBooksDto(apiBooks);
 
         return ResponseEntity
                 .status(HttpStatus.CREATED)
                 .body(ApiResponse.success(null));
     }
+
 
     public BookApiDTO getBookByIsbn(String isbn) {
 
@@ -82,7 +75,7 @@ public class BookApiController {
                 .fromUriString("https://openapi.naver.com")
                 .path("/v1/search/book.json")
                 .queryParam("query", keyword)
-                .queryParam("display", 20)
+                .queryParam("display", 10)
                 .queryParam("start", 1)
                 .queryParam("sort", "sim")
                 .encode()
@@ -92,7 +85,7 @@ public class BookApiController {
         RequestEntity<Void> request = RequestEntity
                 .get(uri)
                 .header("X-Naver-Client-Id", clientId)
-                .header("X-Naver-Client-Secret", clientSecret)
+                .header("X-Naver-Client-Secret", clientKey)
                 .build();
 
         return new RestTemplate().exchange(request, String.class);
@@ -104,6 +97,8 @@ public class BookApiController {
         ObjectMapper om = new ObjectMapper();
         NaverResultDTO resultDTO = new NaverResultDTO();
 
+        System.out.println(response.getBody());
+
         try {
             resultDTO = om.readValue(response.getBody(), NaverResultDTO.class);
         } catch (JsonProcessingException e) {
@@ -113,39 +108,50 @@ public class BookApiController {
         return resultDTO.getItems();
     }
 
-    private List<BookDTO> mapDto(List<BookApiDTO> apiBooks) {
-
-        List<BookDTO> bookList = new ArrayList<>();
+    private void maptoBooksDto(List<BookApiDTO> apiBooks) {
 
         for(BookApiDTO api : apiBooks) {
 
-            BookDTO book = new BookDTO();
-            book.setAuthorName(api.getAuthor());
-            book.setPublisherName(api.getPublisher());
-            LocalDateTime pubdate = formattingDate(api.getPubdate());
-            book.setPublishedAt(pubdate);
+            String bookName = api.getTitle();
+
+            if(api.getPublisher() == null) continue;
+            Publisher publisher = bookApiService.findPublisher(api.getPublisher());
+
+            if(api.getPubdate() == null) continue;;
+            LocalDate pubdate = formattingDate(api.getPubdate());
 
             if (api.getIsbn().isEmpty()) continue;
-            BookApiDTO apiDTO = getBookByIsbn(api.getIsbn());
-            CompletableFuture<BookApiDTO> newBook = bookApiService.addTocAndCategoryName(apiDTO);
-            if(newBook.join().getCategoryName() == null) continue;
-            book.setCategoryName(newBook.join().getCategoryName());
+            String isbn = api.getIsbn();
+            BookApiDTO apiDTO = getBookByIsbn(isbn);
+            CompletableFuture<String> categoryName = bookApiService.addTocAndCategoryName(apiDTO);
+            String categoryNameStr = categoryName.join(); // or get() with exception handling
+            if(categoryNameStr == null) continue;
+            BookCategory bookCategory = bookApiService.findCategoryByCategoryName(categoryNameStr);
 
-            String price = api.getDiscount();
-            book.setPrice((price.isEmpty() ? 0 : Integer.parseInt(api.getDiscount())));
-            book.setStockQuantity(price.isEmpty() ? 0 : 100);
+            if(api.getAuthor() == null) continue;
+            String[] authors = api.getAuthor().split("\\^");
 
-            book.setImageUrl(api.getImage());
-            book.setIsbn(api.getIsbn());
+            int price = api.getDiscount().isEmpty() ? 0 : Integer.parseInt(api.getDiscount());
+            int stockQuantity  = price != 0 ? 100 : 0;
 
-            bookList.add(book);
+            String url = bookApiService.saveFile(api.getImage(), filepath);
+
+            String bookInfo = api.getDescription();
+
+            BookDTO bookDTO = new BookDTO(publisher.getPublisherId(), bookCategory.getCategoryId(), bookName, bookInfo, isbn, pubdate, price, stockQuantity, url);
+
+            Book book = bookApiService.registBook(bookDTO);
+
+            if(book != null) {
+                bookApiService.registAuthor(authors, book.getBookId());
+            }
         }
 
-        return bookList;
+        apiBooks.forEach(System.out::println);
 
     }
 
-    private LocalDateTime formattingDate(String pubdate) {
+    private LocalDate formattingDate(String pubdate) {
 
         SimpleDateFormat formatter1 = new SimpleDateFormat("yyyyMMdd");
         SimpleDateFormat formatter2 = new SimpleDateFormat("yyyy-MM-dd");
@@ -153,7 +159,7 @@ public class BookApiController {
         try {
             Date formatDate = formatter1.parse(pubdate);
             String newDate = formatter2.format(formatDate);
-            return LocalDate.parse(newDate).atStartOfDay();
+            return LocalDate.parse(newDate);
         } catch (ParseException e) {
             throw new RuntimeException(e);
         }
@@ -171,7 +177,7 @@ public class BookApiController {
         RequestEntity<Void> request = RequestEntity
                 .get(uri)
                 .header("X-Naver-Client-Id", clientId)
-                .header("X-Naver-Client-Secret", clientSecret)
+                .header("X-Naver-Client-Secret", clientKey)
                 .build();
 
         return new RestTemplate().exchange(request, String.class);

--- a/src/main/java/com/jamjam/bookjeok/domains/book/contoller/BookApiController.java
+++ b/src/main/java/com/jamjam/bookjeok/domains/book/contoller/BookApiController.java
@@ -45,7 +45,7 @@ public class BookApiController {
     @Value("${image.image-dir}")
     private String filepath;
 
-    @PostMapping("/bookApi/regist")
+    @PostMapping("/bookapi/regist")
     public ResponseEntity<ApiResponse<Void>> registBook(@RequestParam(value = "keyword") String keyword) {
 
         ResponseEntity<String> exchangeResponse = exchange(keyword);

--- a/src/main/java/com/jamjam/bookjeok/domains/book/dto/AuthorDTO.java
+++ b/src/main/java/com/jamjam/bookjeok/domains/book/dto/AuthorDTO.java
@@ -1,0 +1,14 @@
+package com.jamjam.bookjeok.domains.book.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class AuthorDTO {
+
+    private String authorName;
+
+}

--- a/src/main/java/com/jamjam/bookjeok/domains/book/dto/BookApiDTO.java
+++ b/src/main/java/com/jamjam/bookjeok/domains/book/dto/BookApiDTO.java
@@ -1,12 +1,11 @@
 package com.jamjam.bookjeok.domains.book.dto;
 
-import lombok.Getter;
-import lombok.Setter;
-import lombok.ToString;
+import lombok.*;
 
 @Getter
-@Setter
 @ToString
+@NoArgsConstructor
+@AllArgsConstructor
 public class BookApiDTO {
 
     private String title;
@@ -21,4 +20,8 @@ public class BookApiDTO {
     private String toc;
     private String categoryName;
 
+    public BookApiDTO(String toc, String categoryName) {
+        this.toc = toc;
+        this.categoryName = categoryName;
+    }
 }

--- a/src/main/java/com/jamjam/bookjeok/domains/book/dto/BookAuthorDTO.java
+++ b/src/main/java/com/jamjam/bookjeok/domains/book/dto/BookAuthorDTO.java
@@ -1,0 +1,16 @@
+package com.jamjam.bookjeok.domains.book.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class BookAuthorDTO {
+
+    private Long bookId;
+    private Long authorId;
+
+
+}

--- a/src/main/java/com/jamjam/bookjeok/domains/book/dto/BookCategoryDTO.java
+++ b/src/main/java/com/jamjam/bookjeok/domains/book/dto/BookCategoryDTO.java
@@ -1,0 +1,26 @@
+package com.jamjam.bookjeok.domains.book.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class BookCategoryDTO {
+
+    private Long categoryId;
+    private String categoryName;
+    private LocalDateTime createdAt;
+    private LocalDateTime modifiedAt;
+    private boolean isDeleted;
+
+    public BookCategoryDTO(String categoryName, LocalDateTime createdAt, LocalDateTime modifiedAt, boolean isDeleted) {
+        this.categoryName = categoryName;
+        this.createdAt = createdAt;
+        this.modifiedAt = modifiedAt;
+        this.isDeleted = isDeleted;
+    }
+}

--- a/src/main/java/com/jamjam/bookjeok/domains/book/dto/NaverResultDTO.java
+++ b/src/main/java/com/jamjam/bookjeok/domains/book/dto/NaverResultDTO.java
@@ -7,7 +7,6 @@ import java.util.List;
 @ToString
 @NoArgsConstructor
 @AllArgsConstructor
-@Setter
 @Getter
 public class NaverResultDTO {
     private String lastBuildDate;

--- a/src/main/java/com/jamjam/bookjeok/domains/book/dto/PublisherDTO.java
+++ b/src/main/java/com/jamjam/bookjeok/domains/book/dto/PublisherDTO.java
@@ -1,0 +1,18 @@
+package com.jamjam.bookjeok.domains.book.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class PublisherDTO {
+
+    private Long publisherId;
+    private String publisherName;
+
+    public PublisherDTO(String publisherName) {
+        this.publisherName = publisherName;
+    }
+}

--- a/src/main/java/com/jamjam/bookjeok/domains/book/entity/Book.java
+++ b/src/main/java/com/jamjam/bookjeok/domains/book/entity/Book.java
@@ -76,4 +76,26 @@ public class Book {
         this.isDeleted = isDeleted;
     }
 
+    public void changeImageUrl(String imageUrl) {
+        this.imageUrl = imageUrl;
+    }
+
+    public void updateBook(final Long publisherId, final Long categoryId, final String bookName, final String bookInfo,
+                           final String isbn, final LocalDate publishedAt, final int price,
+                           final int stockQuantity, final LocalDateTime modifiedAt) {
+        this.publisherId = publisherId;
+        this.categoryId = categoryId;
+        this.bookName = bookName;
+        this.bookInfo = bookInfo;
+        this.isbn = isbn;
+        this.publishedAt = publishedAt;
+        this.price = price;
+        this.stockQuantity = stockQuantity;
+        this.modifiedAt = modifiedAt;
+    }
+
+    public void deleteBook(final boolean isDeleted) {
+        this.isDeleted = isDeleted;
+    }
+
 }

--- a/src/main/java/com/jamjam/bookjeok/domains/book/entity/BookCategory.java
+++ b/src/main/java/com/jamjam/bookjeok/domains/book/entity/BookCategory.java
@@ -41,4 +41,9 @@ public class BookCategory {
         this.isDeleted = isDeleted;
     }
 
+    public void updateCategory(final String categoryName, final LocalDateTime modifiedAt) {
+        this.categoryName = categoryName;
+        this.modifiedAt = modifiedAt;
+    }
+
 }

--- a/src/main/java/com/jamjam/bookjeok/domains/book/repository/AuthorRepository.java
+++ b/src/main/java/com/jamjam/bookjeok/domains/book/repository/AuthorRepository.java
@@ -1,0 +1,13 @@
+package com.jamjam.bookjeok.domains.book.repository;
+
+import com.jamjam.bookjeok.domains.book.entity.Author;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface AuthorRepository extends JpaRepository<Author, Long> {
+
+    Optional<Author> findByAuthorName(String author);
+}

--- a/src/main/java/com/jamjam/bookjeok/domains/book/repository/BookAuthorRepository.java
+++ b/src/main/java/com/jamjam/bookjeok/domains/book/repository/BookAuthorRepository.java
@@ -1,0 +1,10 @@
+package com.jamjam.bookjeok.domains.book.repository;
+
+import com.jamjam.bookjeok.domains.book.entity.BookAuthor;
+import com.jamjam.bookjeok.domains.book.entity.BookAuthorId;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface BookAuthorRepository extends JpaRepository<BookAuthor, BookAuthorId> {
+}

--- a/src/main/java/com/jamjam/bookjeok/domains/book/repository/BookCategoryRepository.java
+++ b/src/main/java/com/jamjam/bookjeok/domains/book/repository/BookCategoryRepository.java
@@ -1,0 +1,14 @@
+package com.jamjam.bookjeok.domains.book.repository;
+
+import com.jamjam.bookjeok.domains.book.entity.BookCategory;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface BookCategoryRepository extends JpaRepository<BookCategory, Long> {
+
+    Optional<BookCategory> findCategoryByCategoryName(String categoryName);
+
+}

--- a/src/main/java/com/jamjam/bookjeok/domains/book/repository/BookRepository.java
+++ b/src/main/java/com/jamjam/bookjeok/domains/book/repository/BookRepository.java
@@ -1,11 +1,19 @@
 package com.jamjam.bookjeok.domains.book.repository;
 
+import com.jamjam.bookjeok.domains.book.dto.BookDTO;
 import com.jamjam.bookjeok.domains.book.entity.Book;
+import com.jamjam.bookjeok.domains.book.entity.BookCategory;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 
 @Repository
 public interface BookRepository extends JpaRepository<Book, Long> {
 
-    Book findBookByIsbn(String isbn);
+    Optional<Book> findBookByIsbn(String isbn);
+
+    Optional<Book> findBookByBookId(Long aLong);
 }

--- a/src/main/java/com/jamjam/bookjeok/domains/book/repository/PublisherRepository.java
+++ b/src/main/java/com/jamjam/bookjeok/domains/book/repository/PublisherRepository.java
@@ -1,0 +1,14 @@
+package com.jamjam.bookjeok.domains.book.repository;
+
+import com.jamjam.bookjeok.domains.book.entity.Publisher;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface PublisherRepository extends JpaRepository<Publisher, Long> {
+
+    Optional<Publisher> findByPublisherName(String publisherName);
+
+}

--- a/src/main/java/com/jamjam/bookjeok/domains/book/service/BookApiService.java
+++ b/src/main/java/com/jamjam/bookjeok/domains/book/service/BookApiService.java
@@ -1,37 +1,26 @@
 package com.jamjam.bookjeok.domains.book.service;
 
 import com.jamjam.bookjeok.domains.book.dto.BookApiDTO;
-import org.apache.commons.lang3.StringEscapeUtils;
-import org.jsoup.Jsoup;
-import org.jsoup.nodes.Document;
-import org.jsoup.select.Elements;
-import org.springframework.stereotype.Service;
+import com.jamjam.bookjeok.domains.book.dto.BookDTO;
+import com.jamjam.bookjeok.domains.book.entity.Book;
+import com.jamjam.bookjeok.domains.book.entity.BookCategory;
+import com.jamjam.bookjeok.domains.book.entity.Publisher;
 
-import java.io.IOException;
 import java.util.concurrent.CompletableFuture;
 
-@Service
-public class BookApiService {
-    public CompletableFuture<BookApiDTO> addTocAndCategoryName(BookApiDTO book) {
+public interface BookApiService {
 
-        return CompletableFuture.supplyAsync(() -> {
-            try {
-                Document doc = Jsoup.connect(book.getLink()).get();
-                Elements tocElements = doc.select(".bookCatalogTop_category__MLd60");
+    CompletableFuture<String> addTocAndCategoryName(BookApiDTO book);
 
-                if (!tocElements.isEmpty()) {
-                    book.setToc(tocElements.html());
-                    String category = tocElements.last().text();
-                    String categoryName = StringEscapeUtils.unescapeHtml4(category.trim());
-                    if(categoryName.equals("정가제free")) book.setCategoryName(null);
-                    else {
-                        book.setCategoryName(categoryName);
-                    }
-                }
-                return book;
-            } catch (IOException e) {
-                throw new RuntimeException(e);
-            }
-        });
-    }
+    Publisher findPublisher(String publisher);
+
+    BookCategory findCategoryByCategoryName(String categoryNameStr);
+
+    Book registBook(BookDTO bookDTO);
+
+    void registAuthor(String[] authors, Long bookId);
+
+    String saveFile(String imgUrl, String filepath);
+
+    void registBookAuthor(Long bookId, Long authorId);
 }

--- a/src/main/java/com/jamjam/bookjeok/domains/book/service/BookApiServiceImpl.java
+++ b/src/main/java/com/jamjam/bookjeok/domains/book/service/BookApiServiceImpl.java
@@ -1,0 +1,171 @@
+package com.jamjam.bookjeok.domains.book.service;
+
+import com.jamjam.bookjeok.domains.book.dto.*;
+import com.jamjam.bookjeok.domains.book.entity.*;
+import com.jamjam.bookjeok.domains.book.repository.*;
+import com.jamjam.bookjeok.exception.book.FileStorageException;
+import lombok.RequiredArgsConstructor;
+import org.apache.commons.lang3.StringEscapeUtils;
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.jsoup.select.Elements;
+import org.modelmapper.ModelMapper;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.io.*;
+import java.net.URL;
+import java.time.LocalDateTime;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class BookApiServiceImpl implements BookApiService{
+
+    private final BookRepository bookRepository;
+    private final BookCategoryRepository bookCategoryRepository;
+    private final PublisherRepository publisherRepository;
+    private final AuthorRepository authorRepository;
+    private final BookAuthorRepository bookAuthorRepository;
+    private final ModelMapper modelMapper;
+
+    public CompletableFuture<String> addTocAndCategoryName(BookApiDTO book) {
+
+        return CompletableFuture.supplyAsync(() -> {
+
+            try {
+                Document doc = Jsoup.connect(book.getLink()).get();
+                Elements tocElements = doc.select(".bookCatalogTop_category__MLd60");
+
+                if (!tocElements.isEmpty()) {
+
+                    String category = tocElements.last().text();
+                    String categoryName = StringEscapeUtils.unescapeHtml4(category.trim());
+                    if(categoryName.equals("정가제free")) return null;
+                    else {
+                        return categoryName;
+                    }
+                }
+                return null;
+
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        });
+    }
+
+    @Override
+    @Transactional
+    public Book registBook (BookDTO bookDTO) {
+
+        Optional<Book> findBook = bookRepository.findBookByIsbn(bookDTO.getIsbn());
+        Optional<Book> newBook = null;
+
+        if(findBook.isEmpty()) {
+            Book book = modelMapper.map(bookDTO, Book.class);
+            bookRepository.save(book);
+            newBook = bookRepository.findBookByIsbn(bookDTO.getIsbn());
+            return newBook.get();
+        }
+        return null;
+    }
+
+    @Override
+    @Transactional
+    public BookCategory findCategoryByCategoryName(String categoryName) {
+
+        Optional<BookCategory> findCategory = bookCategoryRepository.findCategoryByCategoryName(categoryName);
+        Optional<BookCategory> newCategory = Optional.empty();
+
+        if(findCategory.isEmpty()){
+            BookCategoryDTO categoryDTO  =  new BookCategoryDTO(categoryName, LocalDateTime.now(), LocalDateTime.now(), false) ;
+            BookCategory category = modelMapper.map(categoryDTO, BookCategory.class);
+            bookCategoryRepository.save(category);
+            newCategory = bookCategoryRepository.findCategoryByCategoryName(categoryName);
+            return newCategory.orElseGet(null);
+        }
+        return findCategory.get();
+    }
+
+    @Override
+    @Transactional
+    public Publisher findPublisher(String publisherName) {
+
+        Optional<Publisher> findPublisher = publisherRepository.findByPublisherName(publisherName);
+        Optional<Publisher> newPublisher = Optional.empty();
+
+        if(findPublisher.isEmpty()){
+            PublisherDTO publisherDTO = new PublisherDTO(publisherName);
+            Publisher publisher = modelMapper.map(publisherDTO, Publisher.class);
+            publisherRepository.save(publisher);
+            newPublisher = publisherRepository.findByPublisherName(publisherName);
+            return newPublisher.orElseGet(null);
+        }
+        return findPublisher.get();
+    }
+
+    @Override
+    @Transactional
+    public void registAuthor(String[] authors, Long bookId) {
+
+        for(String author : authors) {
+            Optional<Author> findAuthor = authorRepository.findByAuthorName(author);
+            Optional<Author> newAuthor = Optional.empty();
+            Long authorId = 0L;
+
+            if(findAuthor.isEmpty()){
+                AuthorDTO authorDTO = new AuthorDTO(author);
+                Author mapAuthor = modelMapper.map(authorDTO, Author.class);
+                authorRepository.save(mapAuthor);
+                newAuthor = authorRepository.findByAuthorName(author);
+                authorId = newAuthor.get().getAuthorId();
+            } else  {
+                authorId = findAuthor.get().getAuthorId();
+            }
+
+            registBookAuthor(bookId, authorId);
+
+        }
+    }
+
+    @Transactional
+    public void registBookAuthor(Long bookId, Long authorId) {
+
+        BookAuthorDTO bookAuthorDTO = new BookAuthorDTO(bookId, authorId);
+        BookAuthorId bookAuthorId = modelMapper.map(bookAuthorDTO, BookAuthorId.class);
+        BookAuthor bookAuthor = new BookAuthor(bookAuthorId);
+        bookAuthorRepository.save(bookAuthor);
+
+    }
+
+    @Override
+    public String saveFile(String imgUrl, String filePath){
+        InputStream inputStream = null;
+        FileOutputStream outputStream = null;
+        String fileName = imgUrl.replace("https://shopping-phinf.pstatic.net/", "").replace("/", "");
+        try {
+            inputStream =  new URL(imgUrl).openStream();
+            outputStream = new FileOutputStream(filePath + fileName);
+
+            while(true) {
+                int data = inputStream.read();
+
+                if(data == -1) {
+                    break;
+                }
+                outputStream.write(data);
+            }
+
+            inputStream.close();;
+            outputStream.close();
+
+        } catch (IOException e) {
+            throw new FileStorageException("파일 저장을 실패했습니다.");
+        }
+
+        return filePath + fileName;
+
+    }
+}

--- a/src/main/java/com/jamjam/bookjeok/exception/book/BookExceptionHandler.java
+++ b/src/main/java/com/jamjam/bookjeok/exception/book/BookExceptionHandler.java
@@ -1,0 +1,46 @@
+package com.jamjam.bookjeok.exception.book;
+
+import com.jamjam.bookjeok.common.dto.ApiResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class BookExceptionHandler {
+
+    @ExceptionHandler(RegistPreexistingBookException.class)
+    public ResponseEntity<ApiResponse<Void>> registPreexistingBookExceptionHandler(RegistPreexistingBookException e) {
+
+        String errorCode = HttpStatus.BAD_REQUEST.getReasonPhrase();
+        String errorMessage = e.getMessage();
+
+        return ResponseEntity
+                .badRequest()
+                .body(ApiResponse.failure(errorCode, errorMessage));
+
+    }
+
+    @ExceptionHandler(BookNotFoundException.class)
+    public ResponseEntity<ApiResponse<Void>> bookNotFoundExceptionHandler(BookNotFoundException e) {
+
+        String errorCode = HttpStatus.NOT_FOUND.getReasonPhrase();
+        String errorMessage = e.getMessage();
+
+        return ResponseEntity
+                .badRequest()
+                .body(ApiResponse.failure(errorCode, errorMessage));
+
+    }
+
+    @ExceptionHandler(FileStorageException.class)
+    public ResponseEntity<ApiResponse<Void>> fileStorageExceptionHandler(FileStorageException e) {
+        String errorCode = HttpStatus.SERVICE_UNAVAILABLE.getReasonPhrase();
+        String errorMessage = e.getMessage();
+
+        return ResponseEntity
+                .badRequest()
+                .body(ApiResponse.failure(errorCode, errorMessage));
+    }
+
+}

--- a/src/main/java/com/jamjam/bookjeok/exception/book/BookNotFoundException.java
+++ b/src/main/java/com/jamjam/bookjeok/exception/book/BookNotFoundException.java
@@ -1,0 +1,7 @@
+package com.jamjam.bookjeok.exception.book;
+
+public class BookNotFoundException extends RuntimeException {
+    public BookNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/jamjam/bookjeok/exception/book/FileStorageException.java
+++ b/src/main/java/com/jamjam/bookjeok/exception/book/FileStorageException.java
@@ -1,0 +1,7 @@
+package com.jamjam.bookjeok.exception.book;
+
+public class FileStorageException extends RuntimeException{
+    public FileStorageException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/jamjam/bookjeok/exception/book/RegistPreexistingBookException.java
+++ b/src/main/java/com/jamjam/bookjeok/exception/book/RegistPreexistingBookException.java
@@ -1,0 +1,9 @@
+package com.jamjam.bookjeok.exception.book;
+
+public class RegistPreexistingBookException extends RuntimeException {
+
+    public RegistPreexistingBookException(String message) {
+        super(message);
+    }
+
+}

--- a/src/test/java/com/jamjam/bookjeok/domains/book/controller/BookApiControllerTest.java
+++ b/src/test/java/com/jamjam/bookjeok/domains/book/controller/BookApiControllerTest.java
@@ -1,0 +1,49 @@
+package com.jamjam.bookjeok.domains.book.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.transaction.Transactional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@ActiveProfiles("test")
+@SpringBootTest
+@AutoConfigureMockMvc
+@Transactional
+class BookApiControllerTest {
+
+    @Autowired
+    ObjectMapper mapper;
+
+    @Autowired
+    private MockMvc mvc;
+
+    private static final String BASE_URL = "/api/v1";
+
+    @DisplayName("도서 정보 insert를 위한 API 호출 테스트")
+    @Test
+    void registBook() throws Exception {
+
+        // given
+        String keyword = "김초엽";
+
+        // when
+        String body = mapper.writeValueAsString(keyword);
+
+        // then
+        mvc.perform(post(BASE_URL + "/bookApi/regist")
+                .param("keyword", keyword)
+                .contentType(MediaType.APPLICATION_JSON)
+        )
+        .andExpect(status().isCreated());
+
+    }
+}

--- a/src/test/java/com/jamjam/bookjeok/domains/book/service/BookApiServiceImplTest.java
+++ b/src/test/java/com/jamjam/bookjeok/domains/book/service/BookApiServiceImplTest.java
@@ -1,0 +1,122 @@
+package com.jamjam.bookjeok.domains.book.service;
+
+import com.jamjam.bookjeok.domains.book.dto.BookDTO;
+import com.jamjam.bookjeok.domains.book.entity.Book;
+import com.jamjam.bookjeok.domains.book.entity.BookCategory;
+import com.jamjam.bookjeok.domains.book.entity.Publisher;
+import jakarta.transaction.Transactional;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpStatus;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.time.LocalDate;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+@Slf4j
+@Transactional
+@SpringBootTest
+@ActiveProfiles("test")
+class BookApiServiceImplTest {
+
+    @Autowired
+    private BookApiService bookApiService;
+
+    @DisplayName("Open API를 통한 도서 등록 테스트")
+    @Test
+    void testRegistBookByOpenAPI() {
+
+        LocalDate publishedAt = LocalDate.now();
+        String bookInfo = "테스트용으로 등록된 도서입니다. 저장되었다면 삭제해주세요.";
+        String imgeUrl = "https://shopping-phinf.pstatic.net/main_3245497/32454975970.20230110165450.jpg";
+
+        BookDTO bookDTO = new BookDTO(
+                1L, 1L, "등록성공", bookInfo,
+                "9123456789", publishedAt, 12000, 10, imgeUrl);
+
+
+        Book book = bookApiService.registBook(bookDTO);
+
+        assertThat(book).isNotNull();
+        assertThat(book.getPublisherId()).isEqualTo(1L);
+        assertThat(book.getCategoryId()).isEqualTo(1L);
+        assertThat(book.getBookName()).isEqualTo("등록성공");
+        assertThat(book.getBookInfo()).isEqualTo(bookInfo);
+        assertThat(book.getIsbn()).isEqualTo("9123456789");
+        assertThat(book.getPublishedAt()).isEqualTo(publishedAt);
+        assertThat(book.getPrice()).isEqualTo(12000);
+        assertThat(book.getStockQuantity()).isEqualTo(10);
+        assertThat(book.getImageUrl()).isNotNull();
+
+    }
+
+    @DisplayName("Open API를 통한 중복 도서 저장 테스트")
+    @Test
+    void testRegistBookDuplicatedByOpenAPI() {
+        // isbn 번호 중복 불가
+        String isbn = "9788954672214"; // db에 존재하는 isbn
+
+        LocalDate publishedAt = LocalDate.now();
+        String bookInfo = "테스트용으로 등록된 도서입니다. 저장되었다면 삭제해주세요.";
+        String imgeUrl = "https://shopping-phinf.pstatic.net/main_3245497/32454975970.20230110165450.jpg";
+
+        BookDTO bookDTO = new BookDTO(
+                1L, 1L, "중복 도서", bookInfo,
+                isbn, publishedAt, 12000, 10, imgeUrl);
+
+
+        Book book = bookApiService.registBook(bookDTO);
+
+        assertThat(book).isNull();
+        
+    }
+
+    @DisplayName("카테고리 이름으로 카테고리 정보 가져오기 테스트")
+    @Test
+    void testFindCategoryByCategoryName() {
+
+        String categoryName = "한국소설";
+        BookCategory bookCategory = bookApiService.findCategoryByCategoryName(categoryName);
+
+        assertThat(bookCategory).isNotNull();
+
+    }
+
+    @DisplayName("출판사 이름으로 출판사 정보 가져오기 테스트")
+    @Test
+    void testFindPublisherByName() {
+
+        String publisherName = "민음사";
+        Publisher publisher = bookApiService.findPublisher(publisherName);
+
+        assertThat(publisher).isNotNull();
+
+    }
+
+    @DisplayName("작가 정보 저장 테스트")
+    @Test
+    void registAuthorsByOpenAPI() {
+
+        String[] authorArr = new String[]{"김영하", "다카노 카즈아키", "천쓰홍", "록산 게이"};
+
+        bookApiService.registAuthor(authorArr, 1L);
+
+        assertDoesNotThrow(() -> { return HttpStatus.CREATED;});
+
+    }
+
+    @DisplayName("도서 저자 정보 저장 테스트")
+    @Test
+    void registBookAuthors() {
+
+        bookApiService.registBookAuthor(1L, 1L);
+
+        assertDoesNotThrow(() -> { return HttpStatus.CREATED;});
+
+    }
+}


### PR DESCRIPTION
**네이버 검색 API를 통한 도서 데이터 저장**  Closes: #21 

✅ 도서 API 연동 데이터 저장 비즈니스 로직 작성하기
- 웹 크롤링을 통한 카테고리 데이터 추출 및 도서 카테고리 저장
- API를 통해 전달 받은 도서 데이터 저장

✅ 도서 API 연동 테스트 완료하기
- BookApiController 
  - API 호출 및 응답을 통한 도서 API 비즈니스 로직 처리
- BookApiServiceImpl 
  - API 호출 및 응답을 통한 도서 데이터 저장
  - 중복 도서 등록 방지
  - 카테고리 정보 조회
  - 출판사 정보 조회 
  - 작가 정보 저장 
  - 도서저자 정보 저장