### PR TITLE
[FEAT] 회원의 id로 팔로우 목록 조회하는 기능 구현

### DIFF
--- a/src/main/java/com/jamjam/bookjeok/domains/member/controller/FollowController.java
+++ b/src/main/java/com/jamjam/bookjeok/domains/member/controller/FollowController.java
@@ -1,0 +1,31 @@
+package com.jamjam.bookjeok.domains.member.controller;
+
+import com.jamjam.bookjeok.common.dto.ApiResponse;
+import com.jamjam.bookjeok.domains.member.dto.response.FollowDTO;
+import com.jamjam.bookjeok.domains.member.dto.response.PostSummaryDTO;
+import com.jamjam.bookjeok.domains.member.service.FollowService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1")
+public class FollowController {
+
+    private final FollowService followService;
+
+    @GetMapping("/{memberId}/followings")
+    public ResponseEntity<ApiResponse<List<FollowDTO>>> getFollowListByMemberUid(
+            @PathVariable String memberId
+    ){
+        List<FollowDTO> followList = followService.getFollowingListByMemberId(memberId);
+
+        return ResponseEntity.ok(ApiResponse.success(followList));
+    }
+}

--- a/src/main/java/com/jamjam/bookjeok/domains/member/dto/response/FollowDTO.java
+++ b/src/main/java/com/jamjam/bookjeok/domains/member/dto/response/FollowDTO.java
@@ -1,0 +1,16 @@
+package com.jamjam.bookjeok.domains.member.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@ToString
+@AllArgsConstructor
+public class FollowDTO {
+    
+    private String memberId;
+    private String nickname;
+
+}

--- a/src/main/java/com/jamjam/bookjeok/domains/member/repository/mapper/FollowMapper.java
+++ b/src/main/java/com/jamjam/bookjeok/domains/member/repository/mapper/FollowMapper.java
@@ -1,0 +1,14 @@
+package com.jamjam.bookjeok.domains.member.repository.mapper;
+
+import com.jamjam.bookjeok.domains.member.dto.response.FollowDTO;
+import com.jamjam.bookjeok.domains.member.dto.response.PostSummaryDTO;
+import org.apache.ibatis.annotations.Mapper;
+
+import java.util.List;
+
+@Mapper
+public interface FollowMapper{
+
+    List<FollowDTO> findFollowingListByMemberId(String memberId);
+
+}

--- a/src/main/java/com/jamjam/bookjeok/domains/member/service/FollowService.java
+++ b/src/main/java/com/jamjam/bookjeok/domains/member/service/FollowService.java
@@ -1,0 +1,25 @@
+package com.jamjam.bookjeok.domains.member.service;
+
+import com.jamjam.bookjeok.domains.member.dto.response.FollowDTO;
+import com.jamjam.bookjeok.domains.member.dto.response.PostSummaryDTO;
+import com.jamjam.bookjeok.exception.member.MemberErrorCode;
+import com.jamjam.bookjeok.exception.member.MemberException;
+import com.jamjam.bookjeok.domains.member.repository.mapper.FollowMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class FollowService {
+
+    private final FollowMapper followMapper;
+
+    @Transactional(readOnly = true)
+    public List<FollowDTO> getFollowingListByMemberId(String memberId) {
+
+        return followMapper.findFollowingListByMemberId(memberId);
+    }
+}

--- a/src/main/java/com/jamjam/bookjeok/exception/member/MemberErrorCode.java
+++ b/src/main/java/com/jamjam/bookjeok/exception/member/MemberErrorCode.java
@@ -1,0 +1,17 @@
+package com.jamjam.bookjeok.exception.member;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PACKAGE)
+public enum MemberErrorCode {
+    NOT_FOLLOW("1000", "팔로우 하지 않는 사용자입니다.", HttpStatus.NOT_FOUND),
+    NOT_EXIST_MEMBER("1001", "존재하지 않는 사용자입니다.", HttpStatus.NOT_FOUND);
+
+    private final String code;
+    private final String message;
+    private final HttpStatus httpStatus;
+}

--- a/src/main/java/com/jamjam/bookjeok/exception/member/MemberException.java
+++ b/src/main/java/com/jamjam/bookjeok/exception/member/MemberException.java
@@ -1,0 +1,13 @@
+package com.jamjam.bookjeok.exception.member;
+
+import lombok.Getter;
+
+@Getter
+public class MemberException extends RuntimeException{
+    private final MemberErrorCode memberErrorCode;
+
+    public MemberException(MemberErrorCode memberErrorCode){
+        super(memberErrorCode.getMessage());
+        this.memberErrorCode = memberErrorCode;
+    }
+}

--- a/src/main/java/com/jamjam/bookjeok/exception/member/MemberExceptionHandler.java
+++ b/src/main/java/com/jamjam/bookjeok/exception/member/MemberExceptionHandler.java
@@ -1,0 +1,56 @@
+package com.jamjam.bookjeok.exception.member;
+
+import com.jamjam.bookjeok.common.dto.ApiResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.client.RestClient;
+
+@RestControllerAdvice
+public class MemberExceptionHandler {
+
+    private final RestClient.Builder builder;
+
+    public MemberExceptionHandler(RestClient.Builder builder) {
+        this.builder = builder;
+    }
+
+    @ExceptionHandler(MemberException.class)
+    public ResponseEntity<ApiResponse> handleBusinessException(MemberException e){
+        MemberErrorCode errorCode = e.getMemberErrorCode();
+        ApiResponse<Void> response
+                = ApiResponse.failure(errorCode.getCode(), errorCode.getMessage());
+
+        return new ResponseEntity<>(response,errorCode.getHttpStatus());
+    }
+
+
+//    /* 입력 값 검증 */
+//    @ExceptionHandler(MethodArgumentNotValidException.class)
+//    public ResponseEntity<ApiResponse<Void>> handleValidationException(MethodArgumentNotValidException e){
+//        ErrorCode errorCode = ErrorCode.VALIDATION_ERROR;
+//        StringBuilder errorMessage = new StringBuilder(errorCode.getMessage());
+//
+//        /* 어떤 필드에서 어떤 오류가 나는지 */
+//        for(FieldError error : e.getBindingResult().getFieldErrors()){
+//            errorMessage.append(String.format("[%s : %s]", error.getField(), error.getDefaultMessage()));
+//        }
+//
+//        ApiResponse<Void> response
+//                = ApiResponse.failure(errorCode.getCode(), errorMessage.toString());
+//
+//        return new ResponseEntity<>(response,errorCode.getHttpStatus());
+//    }
+
+//    /* 상위 타입의 예외 하나 선언하기 : 위의 2가지 예외를 제외하고선 만들면 되는 것*/
+//    @ExceptionHandler(Exception.class)
+//    public ResponseEntity<ApiResponse> handleException(){
+//        ErrorCode errorCode = ErrorCode.INTERNAL_SERVER_ERROR;
+//
+//        ApiResponse<Void> response
+//                = ApiResponse.failure(errorCode.getCode(), errorCode.getMessage());
+//
+//        return new ResponseEntity<>(response,errorCode.getHttpStatus());
+//    }
+
+}

--- a/src/main/resources/mappers/member/FollowMapper.xml
+++ b/src/main/resources/mappers/member/FollowMapper.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "https://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.jamjam.bookjeok.domains.member.repository.mapper.FollowMapper">
+
+    <select id="findFollowingListByMemberId" resultType="FollowDTO">
+        SELECT
+            m.member_id,
+            m.nickname
+        FROM follows f
+        JOIN members m ON f.following_id = m.member_uid
+        WHERE f.follower_id = (
+            SELECT member_uid
+            FROM members
+            WHERE member_id = #{ memberId }
+        );
+    </select>
+</mapper>

--- a/src/test/java/com/jamjam/bookjeok/domains/member/controller/FollowControllerTest.java
+++ b/src/test/java/com/jamjam/bookjeok/domains/member/controller/FollowControllerTest.java
@@ -1,0 +1,62 @@
+package com.jamjam.bookjeok.domains.member.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.jamjam.bookjeok.domains.member.dto.response.FollowDTO;
+import com.jamjam.bookjeok.domains.member.service.FollowService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+@Transactional
+class FollowControllerTest {
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @Autowired
+    ObjectMapper objectMapper;
+
+    @MockitoBean
+    private FollowService followService;
+
+    @DisplayName("특정 멤버의 팔로우 목록 가져오기")
+    @Test
+    void getFollowListByMemberUidTest() throws Exception {
+        String memberId = "user01";
+
+        List<FollowDTO> mockFollowList = List.of(
+                new FollowDTO("user02", "닉네임02"),
+                new FollowDTO("user03", "닉네임03")
+        );
+
+        when(followService.getFollowingListByMemberId(memberId)).thenReturn(mockFollowList);
+
+        mockMvc.perform(MockMvcRequestBuilders.get("/api/v1/{memberId}/followings", memberId))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data").isArray())
+                .andExpect(jsonPath("$.data[0].memberId").value("user02"))
+                .andExpect(jsonPath("$.data[0].nickname").value("닉네임02"))
+                .andExpect(jsonPath("$.data[1].memberId").value("user03"))
+                .andExpect(jsonPath("$.data[1].nickname").value("닉네임03"))
+                .andExpect(jsonPath("$.timestamp").exists())
+                .andDo(print());
+    }
+}

--- a/src/test/java/com/jamjam/bookjeok/domains/member/repository/mapper/FollowMapperTest.java
+++ b/src/test/java/com/jamjam/bookjeok/domains/member/repository/mapper/FollowMapperTest.java
@@ -1,0 +1,32 @@
+package com.jamjam.bookjeok.domains.member.repository.mapper;
+
+import com.jamjam.bookjeok.domains.member.dto.response.FollowDTO;
+import com.jamjam.bookjeok.domains.member.dto.response.PostSummaryDTO;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+@ActiveProfiles("test")
+@SpringBootTest
+class FollowMapperTest {
+
+    @Autowired
+    private FollowMapper followMapper;
+
+    @DisplayName("멤버의 Uid로 팔로잉 리스트 가져오기")
+    @Test
+    void findFollowingListByMemberUidTest() {
+        String id = "user01";
+
+        List<FollowDTO> followingListDTO = followMapper.findFollowingListByMemberId(id);
+
+        assertNotNull(followingListDTO);
+        followingListDTO.forEach(System.out::println);
+    }
+}

--- a/src/test/java/com/jamjam/bookjeok/domains/member/service/FollowServiceTest.java
+++ b/src/test/java/com/jamjam/bookjeok/domains/member/service/FollowServiceTest.java
@@ -1,0 +1,55 @@
+package com.jamjam.bookjeok.domains.member.service;
+
+import com.jamjam.bookjeok.domains.member.dto.response.FollowDTO;
+import com.jamjam.bookjeok.domains.member.dto.response.PostSummaryDTO;
+import com.jamjam.bookjeok.domains.member.repository.mapper.FollowMapper;
+import com.jamjam.bookjeok.exception.member.MemberException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.when;
+
+@ActiveProfiles("test")
+@ExtendWith(MockitoExtension.class)
+class FollowServiceTest {
+
+    @Mock
+    private FollowMapper followMapper;
+
+    @InjectMocks
+    private FollowService followService;
+
+    @DisplayName("멤버의 id 통해 팔로우 목록 가져오기")
+    @Test
+    void findFollowingListByMemberId() {
+        // given
+        String memberID = "user01";
+        List<FollowDTO> mockFollowList = List.of(
+                new FollowDTO("user02", "닉네임02"),
+                new FollowDTO("user03", "닉네임03")
+        );
+
+        when(followMapper.findFollowingListByMemberId(memberID)).thenReturn(mockFollowList);
+
+        // when
+        List<FollowDTO> followList = followService.getFollowingListByMemberId(memberID);
+
+        // then
+        assertNotNull(followList);
+        assertEquals(2, followList.size());
+        assertEquals("user02", followList.get(0).getMemberId());
+        assertEquals("닉네임02", followList.get(0).getNickname());
+        assertEquals("user03", followList.get(1).getMemberId());
+        assertEquals("닉네임03", followList.get(1).getNickname());
+
+        followList.forEach(System.out::println);
+    }
+}


### PR DESCRIPTION
회원의 팔로우 목록 조회 기능 구현 (#19)

✅회원의 아이디로 팔로잉 목록 조회하는 기능 구현하기
- 회원이 아이디(memberId)로 조회를 팔로잉 목록 조회를 요청
- 회원이 팔로우 하는 사람의 아이디(memberId)와 닉네임(nickname) 조회