### PR TITLE
[FEAT] 팔로우 하는 회원의 게시글 목록 보기 기능 완료

### DIFF
--- a/src/main/java/com/jamjam/bookjeok/domains/member/controller/FollowController.java
+++ b/src/main/java/com/jamjam/bookjeok/domains/member/controller/FollowController.java
@@ -28,4 +28,15 @@ public class FollowController {
 
         return ResponseEntity.ok(ApiResponse.success(followList));
     }
+
+    @GetMapping("/{writerId}/postList")
+    public ResponseEntity<ApiResponse<List<PostSummaryDTO>>> getPostListByWriterId(
+            @PathVariable String writerId
+    ){
+        List<PostSummaryDTO> postList = followService.getPostListByWriterId(writerId);
+
+        return ResponseEntity.ok(ApiResponse.success(postList));
+
+    }
+
 }

--- a/src/main/java/com/jamjam/bookjeok/domains/member/repository/mapper/FollowMapper.java
+++ b/src/main/java/com/jamjam/bookjeok/domains/member/repository/mapper/FollowMapper.java
@@ -11,4 +11,6 @@ public interface FollowMapper{
 
     List<FollowDTO> findFollowingListByMemberId(String memberId);
 
+    List<PostSummaryDTO> findPostListByMemberId(String memberId);
+
 }

--- a/src/main/java/com/jamjam/bookjeok/domains/member/service/FollowService.java
+++ b/src/main/java/com/jamjam/bookjeok/domains/member/service/FollowService.java
@@ -19,7 +19,19 @@ public class FollowService {
 
     @Transactional(readOnly = true)
     public List<FollowDTO> getFollowingListByMemberId(String memberId) {
-
         return followMapper.findFollowingListByMemberId(memberId);
     }
+
+    @Transactional(readOnly = true)
+    public List<PostSummaryDTO> getPostListByWriterId(String writerId) {
+        return followMapper.findPostListByMemberId(writerId);
+    }
+
+    @Transactional
+    public void createFollow(){
+        // 자기 자신을 팔로우 할 수 없음
+        // 중복으로 follow할 수 없음
+        //
+    }
+
 }

--- a/src/main/java/com/jamjam/bookjeok/domains/member/service/FollowService.java
+++ b/src/main/java/com/jamjam/bookjeok/domains/member/service/FollowService.java
@@ -26,12 +26,4 @@ public class FollowService {
     public List<PostSummaryDTO> getPostListByWriterId(String writerId) {
         return followMapper.findPostListByMemberId(writerId);
     }
-
-    @Transactional
-    public void createFollow(){
-        // 자기 자신을 팔로우 할 수 없음
-        // 중복으로 follow할 수 없음
-        //
-    }
-
 }

--- a/src/main/resources/mappers/member/FollowMapper.xml
+++ b/src/main/resources/mappers/member/FollowMapper.xml
@@ -16,4 +16,19 @@
             WHERE member_id = #{ memberId }
         );
     </select>
+
+    <select id="findPostListByMemberId" resultType="PostSummaryDTO">
+        SELECT
+            m.nickname,
+            p.title
+        FROM posts p
+        JOIN members m ON p.writer_uid = m.member_uid
+        WHERE p.writer_uid = (
+            SELECT member_uid
+            FROM members
+            WHERE member_id = #{ writerId }
+        )
+        ORDER BY p.created_at DESC
+    </select>
+
 </mapper>

--- a/src/test/java/com/jamjam/bookjeok/domains/member/controller/FollowControllerTest.java
+++ b/src/test/java/com/jamjam/bookjeok/domains/member/controller/FollowControllerTest.java
@@ -2,6 +2,7 @@ package com.jamjam.bookjeok.domains.member.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.jamjam.bookjeok.domains.member.dto.response.FollowDTO;
+import com.jamjam.bookjeok.domains.member.dto.response.PostSummaryDTO;
 import com.jamjam.bookjeok.domains.member.service.FollowService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -59,4 +60,38 @@ class FollowControllerTest {
                 .andExpect(jsonPath("$.timestamp").exists())
                 .andDo(print());
     }
+
+    @DisplayName("팔로우하는 멤버의 게시글 목록 가져오기")
+    @Test
+    void getPostListByWriterIdTest() throws Exception {
+        String writerId = "user02";
+
+        List<PostSummaryDTO> mockPostList = List.of(
+                PostSummaryDTO.builder()
+                        .nickname("닉네임02")
+                        .title("제목1")
+                        .build(),
+                PostSummaryDTO.builder()
+                        .nickname("닉네임02")
+                        .title("제목2")
+                        .build()
+        );
+
+        when(followService.getPostListByWriterId(writerId)).thenReturn(mockPostList);
+
+        mockMvc.perform(MockMvcRequestBuilders.get("/api/v1/{writerId}/postList", writerId))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data").isArray())
+                .andExpect(jsonPath("$.data.length()").value(2))
+                .andExpect(jsonPath("$.data[0].nickname").value("닉네임02"))
+                .andExpect(jsonPath("$.data[0].title").value("제목1"))
+                .andExpect(jsonPath("$.data[1].nickname").value("닉네임02"))
+                .andExpect(jsonPath("$.data[1].title").value("제목2"))
+                .andExpect(jsonPath("$.timestamp").exists())
+                .andDo(print());
+
+    }
+
+
 }

--- a/src/test/java/com/jamjam/bookjeok/domains/member/repository/mapper/FollowMapperTest.java
+++ b/src/test/java/com/jamjam/bookjeok/domains/member/repository/mapper/FollowMapperTest.java
@@ -19,7 +19,7 @@ class FollowMapperTest {
     @Autowired
     private FollowMapper followMapper;
 
-    @DisplayName("멤버의 Uid로 팔로잉 리스트 가져오기")
+    @DisplayName("멤버의 id로 팔로잉 리스트 가져오기")
     @Test
     void findFollowingListByMemberUidTest() {
         String id = "user01";
@@ -29,4 +29,15 @@ class FollowMapperTest {
         assertNotNull(followingListDTO);
         followingListDTO.forEach(System.out::println);
     }
+
+    @DisplayName("멤버의 id로 게시글 목록 가져오기")
+    @Test
+    void findPostListByMemberIdTest(){
+        String id = "user02";
+
+        List<PostSummaryDTO> postSummaryList = followMapper.findPostListByMemberId(id);
+
+        assertNotNull(postSummaryList);
+    }
+
 }

--- a/src/test/java/com/jamjam/bookjeok/domains/member/service/FollowServiceTest.java
+++ b/src/test/java/com/jamjam/bookjeok/domains/member/service/FollowServiceTest.java
@@ -52,4 +52,29 @@ class FollowServiceTest {
 
         followList.forEach(System.out::println);
     }
+
+
+    @DisplayName("팔로우한 사용자의 게시글 목록 정상 조회")
+    @Test
+    void getPostsByWriterIdTest() {
+        String writerId = "user02";
+
+        List<PostSummaryDTO> mockPostList = List.of(
+                PostSummaryDTO.builder()
+                        .nickname("닉네임02")
+                        .title("제목1")
+                        .build(),
+                PostSummaryDTO.builder()
+                        .nickname("닉네임02")
+                        .title("제목2")
+                        .build()
+        );
+
+
+        when(followMapper.findPostListByMemberId(writerId)).thenReturn(mockPostList);
+
+        List<PostSummaryDTO> postList = followService.getPostListByWriterId(writerId);
+
+        assertNotNull(postList);
+    }
 }


### PR DESCRIPTION
✅ 회원의 아이디를 통해 게시글 목록 조회하기

- Controller
   - /{writerId}/postList로 요청
   - Controller 테스트 완료
- Service  
   - Service 테스트 완료
- Mapper
  - Mapper 테스트 완료