### PR TITLE
[FEAT] 관심 작가 추가하기

### DIFF
--- a/src/main/java/com/jamjam/bookjeok/domains/member/controller/InterestAuthorController.java
+++ b/src/main/java/com/jamjam/bookjeok/domains/member/controller/InterestAuthorController.java
@@ -2,13 +2,14 @@ package com.jamjam.bookjeok.domains.member.controller;
 
 import com.jamjam.bookjeok.common.dto.ApiResponse;
 import com.jamjam.bookjeok.domains.member.dto.InterestAuthorDTO;
+import com.jamjam.bookjeok.domains.member.dto.request.InterestAuthorCreatRequest;
+import com.jamjam.bookjeok.domains.member.dto.response.InterestAuthorResponse;
 import com.jamjam.bookjeok.domains.member.service.InterestAuthorService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
@@ -29,5 +30,21 @@ public class InterestAuthorController {
 
         return ResponseEntity.ok(ApiResponse.success(interestAuthorList));
 
+    }
+
+    @PostMapping("/interest-author")
+    public ResponseEntity<ApiResponse<InterestAuthorResponse>> createInterestAuthor(
+            @RequestBody @Validated InterestAuthorCreatRequest request
+    ){
+
+        interestAuthorService.createInterestAuthor(request);
+
+        InterestAuthorResponse response = InterestAuthorResponse.builder()
+                .authorName(request.getAuthorName())
+                .build();
+
+        return ResponseEntity
+                .status(HttpStatus.CREATED)
+                .body(ApiResponse.success(response));
     }
 }

--- a/src/main/java/com/jamjam/bookjeok/domains/member/dto/request/InterestAuthorCreatRequest.java
+++ b/src/main/java/com/jamjam/bookjeok/domains/member/dto/request/InterestAuthorCreatRequest.java
@@ -1,0 +1,17 @@
+package com.jamjam.bookjeok.domains.member.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class InterestAuthorCreatRequest {
+
+    @NotNull(message = "저자의 이름은 비어있을 수 없습니다.")
+    private final String authorName;
+
+    @NotNull(message = "멤버 아이디는 비어있을 수 없습니다.")
+    private final Long memberUid;
+
+}

--- a/src/main/java/com/jamjam/bookjeok/domains/member/dto/response/InterestAuthorResponse.java
+++ b/src/main/java/com/jamjam/bookjeok/domains/member/dto/response/InterestAuthorResponse.java
@@ -1,0 +1,12 @@
+package com.jamjam.bookjeok.domains.member.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class InterestAuthorResponse {
+
+    private String authorName;
+
+}

--- a/src/main/java/com/jamjam/bookjeok/domains/member/entity/InterestAuthor.java
+++ b/src/main/java/com/jamjam/bookjeok/domains/member/entity/InterestAuthor.java
@@ -2,6 +2,7 @@ package com.jamjam.bookjeok.domains.member.entity;
 
 import jakarta.persistence.*;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -13,5 +14,10 @@ public class InterestAuthor {
 
     @Id @EmbeddedId
     private InterestAuthorId interestAuthorId;
+
+    @Builder
+    public InterestAuthor(InterestAuthorId interestAuthorId){
+        this.interestAuthorId = interestAuthorId;
+    }
 
 }

--- a/src/main/java/com/jamjam/bookjeok/domains/member/repository/mapper/InterestAuthorMapper.java
+++ b/src/main/java/com/jamjam/bookjeok/domains/member/repository/mapper/InterestAuthorMapper.java
@@ -10,4 +10,6 @@ public interface InterestAuthorMapper {
 
     List<InterestAuthorDTO> findInterestAuthorByMemberId(String memberId);
 
+    int countInterestAuthor(Long memberUid);
+
 }

--- a/src/main/java/com/jamjam/bookjeok/domains/member/repository/repository/InterestAuthorRepository.java
+++ b/src/main/java/com/jamjam/bookjeok/domains/member/repository/repository/InterestAuthorRepository.java
@@ -1,0 +1,13 @@
+package com.jamjam.bookjeok.domains.member.repository.repository;
+
+import com.jamjam.bookjeok.domains.member.entity.InterestAuthor;
+import com.jamjam.bookjeok.domains.member.entity.InterestAuthorId;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface InterestAuthorRepository extends JpaRepository<InterestAuthor, InterestAuthorId> {
+
+
+}

--- a/src/main/java/com/jamjam/bookjeok/exception/member/MemberErrorCode.java
+++ b/src/main/java/com/jamjam/bookjeok/exception/member/MemberErrorCode.java
@@ -9,7 +9,11 @@ import org.springframework.http.HttpStatus;
 @AllArgsConstructor(access = AccessLevel.PACKAGE)
 public enum MemberErrorCode {
     NOT_FOLLOW("1000", "팔로우 하지 않는 사용자입니다.", HttpStatus.NOT_FOUND),
-    NOT_EXIST_MEMBER("1001", "존재하지 않는 사용자입니다.", HttpStatus.NOT_FOUND);
+    NOT_EXIST_MEMBER("1001", "존재하지 않는 사용자입니다.", HttpStatus.NOT_FOUND),
+    MEMBER_SEARCH_CONDITION_MISSING("1002", "memberId 또는 nickname 중 하나는 필수입니다", HttpStatus.BAD_REQUEST),
+    NOT_FOUND_AUTHOR("1003", "존재하지 않는 작가입니다.", HttpStatus.NOT_FOUND),
+    ALREADY_INTERESTED_AUTHOR("1004", "이미 즐겨찾기에 추가한 작가입니다.", HttpStatus.ALREADY_REPORTED),
+    INTEREST_AUTHOR_LIMIT_EXCEEDED("1005","관심 작가는 최대 30명까지 등록할 수 있습니다.", HttpStatus.TOO_MANY_REQUESTS);
 
     private final String code;
     private final String message;

--- a/src/main/java/com/jamjam/bookjeok/exception/member/MemberExceptionHandler.java
+++ b/src/main/java/com/jamjam/bookjeok/exception/member/MemberExceptionHandler.java
@@ -1,22 +1,17 @@
 package com.jamjam.bookjeok.exception.member;
 
 import com.jamjam.bookjeok.common.dto.ApiResponse;
+import com.jamjam.bookjeok.exception.member.interestAuthorException.AlreadyInterestedAuthorException;
+import com.jamjam.bookjeok.exception.member.interestAuthorException.AuthorNotFoundException;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
-import org.springframework.web.client.RestClient;
 
 @RestControllerAdvice
 public class MemberExceptionHandler {
 
-    private final RestClient.Builder builder;
-
-    public MemberExceptionHandler(RestClient.Builder builder) {
-        this.builder = builder;
-    }
-
     @ExceptionHandler(MemberException.class)
-    public ResponseEntity<ApiResponse> handleBusinessException(MemberException e){
+    public ResponseEntity<ApiResponse> handleMemberException(MemberException e){
         MemberErrorCode errorCode = e.getMemberErrorCode();
         ApiResponse<Void> response
                 = ApiResponse.failure(errorCode.getCode(), errorCode.getMessage());
@@ -24,33 +19,21 @@ public class MemberExceptionHandler {
         return new ResponseEntity<>(response,errorCode.getHttpStatus());
     }
 
+    @ExceptionHandler(AuthorNotFoundException.class)
+    public ResponseEntity<ApiResponse> handleAuthorNotFoundException(AuthorNotFoundException e){
+        MemberErrorCode errorCode = e.getMemberErrorCode();
+        ApiResponse<Void> response
+                = ApiResponse.failure(errorCode.getCode(), errorCode.getMessage());
 
-//    /* 입력 값 검증 */
-//    @ExceptionHandler(MethodArgumentNotValidException.class)
-//    public ResponseEntity<ApiResponse<Void>> handleValidationException(MethodArgumentNotValidException e){
-//        ErrorCode errorCode = ErrorCode.VALIDATION_ERROR;
-//        StringBuilder errorMessage = new StringBuilder(errorCode.getMessage());
-//
-//        /* 어떤 필드에서 어떤 오류가 나는지 */
-//        for(FieldError error : e.getBindingResult().getFieldErrors()){
-//            errorMessage.append(String.format("[%s : %s]", error.getField(), error.getDefaultMessage()));
-//        }
-//
-//        ApiResponse<Void> response
-//                = ApiResponse.failure(errorCode.getCode(), errorMessage.toString());
-//
-//        return new ResponseEntity<>(response,errorCode.getHttpStatus());
-//    }
+        return new ResponseEntity<>(response,errorCode.getHttpStatus());
+    }
 
-//    /* 상위 타입의 예외 하나 선언하기 : 위의 2가지 예외를 제외하고선 만들면 되는 것*/
-//    @ExceptionHandler(Exception.class)
-//    public ResponseEntity<ApiResponse> handleException(){
-//        ErrorCode errorCode = ErrorCode.INTERNAL_SERVER_ERROR;
-//
-//        ApiResponse<Void> response
-//                = ApiResponse.failure(errorCode.getCode(), errorCode.getMessage());
-//
-//        return new ResponseEntity<>(response,errorCode.getHttpStatus());
-//    }
+    @ExceptionHandler(AlreadyInterestedAuthorException.class)
+    public ResponseEntity<ApiResponse> handleAlreadyInterestedAuthorException(AlreadyInterestedAuthorException e){
+        MemberErrorCode errorCode = e.getMemberErrorCode();
+        ApiResponse<Void> response
+                = ApiResponse.failure(errorCode.getCode(), errorCode.getMessage());
 
+        return new ResponseEntity<>(response,errorCode.getHttpStatus());
+    }
 }

--- a/src/main/java/com/jamjam/bookjeok/exception/member/interestAuthorException/AlreadyInterestedAuthorException.java
+++ b/src/main/java/com/jamjam/bookjeok/exception/member/interestAuthorException/AlreadyInterestedAuthorException.java
@@ -1,0 +1,15 @@
+package com.jamjam.bookjeok.exception.member.interestAuthorException;
+
+import com.jamjam.bookjeok.exception.member.MemberErrorCode;
+import lombok.Getter;
+
+@Getter
+public class AlreadyInterestedAuthorException extends RuntimeException {
+
+    private final MemberErrorCode memberErrorCode;
+
+    public AlreadyInterestedAuthorException(MemberErrorCode memberErrorCode) {
+        super(memberErrorCode.getCode());
+        this.memberErrorCode = memberErrorCode;
+    }
+}

--- a/src/main/java/com/jamjam/bookjeok/exception/member/interestAuthorException/AuthorNotFoundException.java
+++ b/src/main/java/com/jamjam/bookjeok/exception/member/interestAuthorException/AuthorNotFoundException.java
@@ -1,0 +1,14 @@
+package com.jamjam.bookjeok.exception.member.interestAuthorException;
+
+import com.jamjam.bookjeok.exception.member.MemberErrorCode;
+import lombok.Getter;
+
+@Getter
+public class AuthorNotFoundException extends RuntimeException{
+    private final MemberErrorCode memberErrorCode;
+
+    public AuthorNotFoundException(MemberErrorCode memberErrorCode) {
+        super(memberErrorCode.getCode());
+        this.memberErrorCode = memberErrorCode;
+    }
+}

--- a/src/main/java/com/jamjam/bookjeok/exception/member/interestAuthorException/InterestAuthorLimitExceededException.java
+++ b/src/main/java/com/jamjam/bookjeok/exception/member/interestAuthorException/InterestAuthorLimitExceededException.java
@@ -1,0 +1,15 @@
+package com.jamjam.bookjeok.exception.member.interestAuthorException;
+
+import com.jamjam.bookjeok.exception.member.MemberErrorCode;
+import lombok.Getter;
+
+@Getter
+public class InterestAuthorLimitExceededException extends RuntimeException{
+
+    private final MemberErrorCode memberErrorCode;
+
+    public InterestAuthorLimitExceededException(MemberErrorCode memberErrorCode) {
+        super(memberErrorCode.getCode());
+        this.memberErrorCode = memberErrorCode;
+    }
+}

--- a/src/main/resources/mappers/member/InterestAuthorMapper.xml
+++ b/src/main/resources/mappers/member/InterestAuthorMapper.xml
@@ -21,4 +21,10 @@
         JOIN members m ON ia.member_uid = m.member_uid
         WHERE m.member_id = #{ memberId };
     </select>
+
+    <select id="countInterestAuthor" resultType="_int">
+        SELECT COUNT(*)
+        FROM interest_authors
+        WHERE member_uid = #{ memberUid }
+    </select>
 </mapper>

--- a/src/test/java/com/jamjam/bookjeok/domains/member/controller/InterestAuthorControllerTest.java
+++ b/src/test/java/com/jamjam/bookjeok/domains/member/controller/InterestAuthorControllerTest.java
@@ -1,19 +1,21 @@
 package com.jamjam.bookjeok.domains.member.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.jamjam.bookjeok.domains.member.dto.request.InterestAuthorCreatRequest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.transaction.annotation.Transactional;
 
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @SpringBootTest
 @Transactional
@@ -40,6 +42,20 @@ public class InterestAuthorControllerTest {
                 .andExpect(jsonPath("$.data[0].bookList[0].bookName").value("태백산맥 1권"))
                 .andExpect(jsonPath("$.timestamp").exists())
                 .andDo(print());
+    }
+
+    @DisplayName("즐겨찾기 등록하기")
+    @Test
+    void createInterestAuthorTest() throws Exception {
+        InterestAuthorCreatRequest request = new InterestAuthorCreatRequest("공지영", 2L);
+
+        mockMvc.perform(post("/api/v1/interest-author")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.authorName").value("공지영"))
+                .andReturn();
     }
 
 }

--- a/src/test/java/com/jamjam/bookjeok/domains/member/repository/mapper/InterestAuthorMapperTest.java
+++ b/src/test/java/com/jamjam/bookjeok/domains/member/repository/mapper/InterestAuthorMapperTest.java
@@ -9,6 +9,7 @@ import org.springframework.test.context.ActiveProfiles;
 
 import java.util.List;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 @ActiveProfiles("test")
@@ -28,6 +29,16 @@ class InterestAuthorMapperTest {
         assertNotNull(interestAuthorList);
         interestAuthorList.forEach(System.out::println);
 
+    }
+
+    @DisplayName("회원의 관심 작가 수 가져오기")
+    @Test
+    void countInterestAuthorTest(){
+        Long memberUid = 2L;
+
+        int totalInterestAuthor = interestAuthorMapper.countInterestAuthor(memberUid);
+
+        assertEquals(3, totalInterestAuthor);
     }
 
 }

--- a/src/test/java/com/jamjam/bookjeok/domains/member/service/InterestAuthorServiceTest.java
+++ b/src/test/java/com/jamjam/bookjeok/domains/member/service/InterestAuthorServiceTest.java
@@ -1,6 +1,10 @@
 package com.jamjam.bookjeok.domains.member.service;
 
 import com.jamjam.bookjeok.domains.member.dto.InterestAuthorDTO;
+import com.jamjam.bookjeok.domains.member.dto.request.InterestAuthorCreatRequest;
+import com.jamjam.bookjeok.exception.member.interestAuthorException.AlreadyInterestedAuthorException;
+import com.jamjam.bookjeok.exception.member.interestAuthorException.AuthorNotFoundException;
+import com.jamjam.bookjeok.exception.member.interestAuthorException.InterestAuthorLimitExceededException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -10,8 +14,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.*;
 
 @ActiveProfiles("test")
 @Transactional
@@ -24,11 +27,60 @@ public class InterestAuthorServiceTest {
     @DisplayName("회원의 책 즐겨찾기 목록 가져오기")
     @Test
     void findInterestAuthorByMemberIdTest(){
-        String memberId = "user01";
+        String memberId = "user02";
 
         List<InterestAuthorDTO> interestAuthorList
                 = interestAuthorService.getInterestAuthorList(memberId);
 
         assertNotNull(interestAuthorList);
     }
+
+    @DisplayName("관심 작가 등록하기")
+    @Test
+    void createInterestAuthorTest(){
+        Long memberUid = 2L;
+
+        String authorName1 = "공지영";
+        InterestAuthorCreatRequest request1 = new InterestAuthorCreatRequest(authorName1, memberUid);
+        String response = interestAuthorService.createInterestAuthor(request1);
+        assertEquals("공지영", response);
+
+    }
+
+    @DisplayName("관심 작가 등록시 작가가 없는 경우 예외 테스트")
+    @Test
+    void createInterestAuthorExceptionTest1(){
+        Long memberUid = 2L;
+
+        String authorName2 = "정유진";
+        InterestAuthorCreatRequest request2 = new InterestAuthorCreatRequest(authorName2, memberUid);
+        assertThrows(AuthorNotFoundException.class, () -> {
+            interestAuthorService.createInterestAuthor(request2);
+        });
+    }
+
+    @DisplayName("관심 작가 등록시 이미 등록 된 작가인 경우 예외 테스트")
+    @Test
+    void createInterestAuthorExceptionTest2(){
+        Long memberUid = 2L;
+
+        String authorName3 = "정약용";
+        InterestAuthorCreatRequest request3 = new InterestAuthorCreatRequest(authorName3, memberUid);
+        assertThrows(AlreadyInterestedAuthorException.class, () -> {
+            interestAuthorService.createInterestAuthor(request3);
+        });
+    }
+
+    @DisplayName("관심자가 30명 초과시 발생하는 예외 테스트")
+    @Test
+    void interestAuthorLimitTest(){
+        Long memberUid = 2L;
+
+        String authorName3 = "정약용";
+        InterestAuthorCreatRequest request3 = new InterestAuthorCreatRequest(authorName3, memberUid);
+        assertThrows(InterestAuthorLimitExceededException.class, () -> {
+            interestAuthorService.createInterestAuthor(request3);
+        });
+    }
+
 }


### PR DESCRIPTION
 ✅회원의 관심 작가 추가하기

- InterestAuthorCreateRequest로 회원의 아이디와 작가의 이름을 받기
- InterestAuthorResponse로 작가를 추가했을 경우 작가의 이름 반환하기
- 관심 작가 추가 Controller 작성
  -  관심 작가 추가 Controller 테스트 
- 관심 작가 추가 Service 작성
   - 관심 작가 등록 시 30명 초과하지 않게 등록 시 확인해서 예외 처리
   - 이미 관심 작가에 등록된 작가인 경우 추가하지 않기
   - 추가하려는 작가가 존재하지 않는 경우 예외처리
   - 관심 작가 추가 Service 테스트
- 관심 작가 추가 Repository작성


