### PR TITLE
[FEATURE] 회원의 전체 목록 조회 기능

### DIFF
--- a/src/main/java/com/jamjam/bookjeok/domains/member/controller/AdminController.java
+++ b/src/main/java/com/jamjam/bookjeok/domains/member/controller/AdminController.java
@@ -1,0 +1,36 @@
+package com.jamjam.bookjeok.domains.member.controller;
+
+import com.jamjam.bookjeok.common.dto.ApiResponse;
+import com.jamjam.bookjeok.domains.member.dto.request.PageRequest;
+import com.jamjam.bookjeok.domains.member.dto.request.MemberSearchRequest;
+import com.jamjam.bookjeok.domains.member.dto.response.MemberDetailResponse;
+import com.jamjam.bookjeok.domains.member.dto.response.MemberListResponse;
+import com.jamjam.bookjeok.domains.member.service.AdminService;
+import com.jamjam.bookjeok.exception.member.MemberErrorCode;
+import com.jamjam.bookjeok.exception.member.MemberException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1")
+@RequiredArgsConstructor
+@Slf4j
+public class AdminController {
+
+    private final AdminService adminService;
+
+    @GetMapping("/admin/members")
+    public ResponseEntity<ApiResponse<MemberListResponse>> getAllMembers(
+            @Validated PageRequest pageRequest
+    ){
+        MemberListResponse response = adminService.getAllMembers(pageRequest);
+
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+}

--- a/src/main/java/com/jamjam/bookjeok/domains/member/controller/InterestAuthorController.java
+++ b/src/main/java/com/jamjam/bookjeok/domains/member/controller/InterestAuthorController.java
@@ -2,7 +2,7 @@ package com.jamjam.bookjeok.domains.member.controller;
 
 import com.jamjam.bookjeok.common.dto.ApiResponse;
 import com.jamjam.bookjeok.domains.member.dto.InterestAuthorDTO;
-import com.jamjam.bookjeok.domains.member.dto.request.InterestAuthorCreatRequest;
+import com.jamjam.bookjeok.domains.member.dto.request.InterestAuthorRequest;
 import com.jamjam.bookjeok.domains.member.dto.response.InterestAuthorResponse;
 import com.jamjam.bookjeok.domains.member.service.InterestAuthorService;
 import lombok.RequiredArgsConstructor;
@@ -20,7 +20,7 @@ public class InterestAuthorController {
 
     private final InterestAuthorService interestAuthorService;
 
-    @GetMapping("{memberId}/interest-authors")
+    @GetMapping("/{memberId}/interest-authors")
     public ResponseEntity<ApiResponse<List<InterestAuthorDTO>>> getInterestAuthorByMemberId(
             @PathVariable String memberId
     ){
@@ -34,7 +34,7 @@ public class InterestAuthorController {
 
     @PostMapping("/interest-author")
     public ResponseEntity<ApiResponse<InterestAuthorResponse>> createInterestAuthor(
-            @RequestBody @Validated InterestAuthorCreatRequest request
+            @RequestBody @Validated InterestAuthorRequest request
     ){
 
         interestAuthorService.createInterestAuthor(request);
@@ -47,4 +47,14 @@ public class InterestAuthorController {
                 .status(HttpStatus.CREATED)
                 .body(ApiResponse.success(response));
     }
+
+    @DeleteMapping("/interest-author")
+    public ResponseEntity<ApiResponse<Void>> deleteInterestAuthor(
+            @RequestBody @Validated InterestAuthorRequest request
+    ){
+        interestAuthorService.deleteInterestAuthor(request);
+
+        return ResponseEntity.ok(ApiResponse.success(null));
+    }
+
 }

--- a/src/main/java/com/jamjam/bookjeok/domains/member/dto/request/InterestAuthorRequest.java
+++ b/src/main/java/com/jamjam/bookjeok/domains/member/dto/request/InterestAuthorRequest.java
@@ -6,7 +6,7 @@ import lombok.RequiredArgsConstructor;
 
 @Getter
 @RequiredArgsConstructor
-public class InterestAuthorCreatRequest {
+public class InterestAuthorRequest {
 
     @NotNull(message = "저자의 이름은 비어있을 수 없습니다.")
     private final String authorName;

--- a/src/main/java/com/jamjam/bookjeok/domains/member/dto/request/PageRequest.java
+++ b/src/main/java/com/jamjam/bookjeok/domains/member/dto/request/PageRequest.java
@@ -1,0 +1,25 @@
+package com.jamjam.bookjeok.domains.member.dto.request;
+
+import jakarta.validation.constraints.Min;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class PageRequest {
+
+    @Min(value = 1)
+    private Integer page = 1;
+
+    @Min(value = 1)
+    private Integer size = 10;
+
+    public int getOffset(){
+        return (page-1) * size;
+    }
+
+    public int getLimit(){
+        return size;
+    }
+}

--- a/src/main/java/com/jamjam/bookjeok/domains/member/dto/response/MemberListResponse.java
+++ b/src/main/java/com/jamjam/bookjeok/domains/member/dto/response/MemberListResponse.java
@@ -1,0 +1,17 @@
+package com.jamjam.bookjeok.domains.member.dto.response;
+
+import com.jamjam.bookjeok.common.dto.Pagination;
+import com.jamjam.bookjeok.domains.member.dto.MemberDTO;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class MemberListResponse {
+
+    private List<MemberDTO> memberList;
+    private final Pagination pagination;
+
+}

--- a/src/main/java/com/jamjam/bookjeok/domains/member/repository/mapper/AdminMapper.java
+++ b/src/main/java/com/jamjam/bookjeok/domains/member/repository/mapper/AdminMapper.java
@@ -1,0 +1,17 @@
+package com.jamjam.bookjeok.domains.member.repository.mapper;
+
+import com.jamjam.bookjeok.domains.member.dto.request.PageRequest;
+import com.jamjam.bookjeok.domains.member.dto.request.MemberSearchRequest;
+import com.jamjam.bookjeok.domains.member.dto.MemberDTO;
+import org.apache.ibatis.annotations.Mapper;
+
+import java.util.List;
+
+@Mapper
+public interface AdminMapper {
+
+    List<MemberDTO> findAllMember(PageRequest pageRequest);
+
+    long countMembers();
+
+}

--- a/src/main/java/com/jamjam/bookjeok/domains/member/service/AdminService.java
+++ b/src/main/java/com/jamjam/bookjeok/domains/member/service/AdminService.java
@@ -1,0 +1,45 @@
+package com.jamjam.bookjeok.domains.member.service;
+
+import com.jamjam.bookjeok.common.dto.Pagination;
+import com.jamjam.bookjeok.domains.member.dto.request.PageRequest;
+import com.jamjam.bookjeok.domains.member.dto.request.MemberSearchRequest;
+import com.jamjam.bookjeok.domains.member.dto.MemberDTO;
+import com.jamjam.bookjeok.domains.member.dto.response.MemberDetailResponse;
+import com.jamjam.bookjeok.domains.member.dto.response.MemberListResponse;
+import com.jamjam.bookjeok.domains.member.repository.mapper.AdminMapper;
+import com.jamjam.bookjeok.exception.member.MemberErrorCode;
+import com.jamjam.bookjeok.exception.member.MemberException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class AdminService {
+
+    private final AdminMapper adminMapper;
+
+    // 멤버의 전체 목록을 조회하는 기능
+    @Transactional(readOnly = true)
+    public MemberListResponse getAllMembers(PageRequest pageRequest) {
+        List<MemberDTO> members = adminMapper.findAllMember(pageRequest);
+
+        // 페이징 처리를 위해 전체 멤버의 수 조회하기
+        long totalItems = adminMapper.countMembers();
+
+        int page = pageRequest.getPage();
+        int size = pageRequest.getSize();
+
+        return MemberListResponse.builder()
+                .memberList(members)
+                .pagination(Pagination.builder()
+                    .currentPage(page)
+                    .totalPage((int)Math.ceil((double)totalItems/size))
+                    .totalItems(totalItems)
+                    .build())
+                .build();
+    }
+}

--- a/src/main/java/com/jamjam/bookjeok/domains/member/service/InterestAuthorService.java
+++ b/src/main/java/com/jamjam/bookjeok/domains/member/service/InterestAuthorService.java
@@ -3,7 +3,7 @@ package com.jamjam.bookjeok.domains.member.service;
 import com.jamjam.bookjeok.domains.book.entity.Author;
 import com.jamjam.bookjeok.domains.book.repository.AuthorRepository;
 import com.jamjam.bookjeok.domains.member.dto.InterestAuthorDTO;
-import com.jamjam.bookjeok.domains.member.dto.request.InterestAuthorCreatRequest;
+import com.jamjam.bookjeok.domains.member.dto.request.InterestAuthorRequest;
 import com.jamjam.bookjeok.domains.member.entity.InterestAuthor;
 import com.jamjam.bookjeok.domains.member.entity.InterestAuthorId;
 import com.jamjam.bookjeok.domains.member.repository.mapper.InterestAuthorMapper;
@@ -36,10 +36,10 @@ public class InterestAuthorService {
     }
 
     @Transactional
-    public String createInterestAuthor(InterestAuthorCreatRequest interestAuthorCreatRequest){
+    public String createInterestAuthor(InterestAuthorRequest interestAuthorRequest){
 
         int totalInterestAuthor = interestAuthorMapper
-                .countInterestAuthor(interestAuthorCreatRequest.getMemberUid());
+                .countInterestAuthor(interestAuthorRequest.getMemberUid());
 
         // 작가의 인원이 30명이라면 추가할 수 없음
         if(totalInterestAuthor == 30){
@@ -47,12 +47,12 @@ public class InterestAuthorService {
         }
 
         // 작가 가져오기 (작가의 아이디를 가져오기 위해서 가져오는 것)
-        Author author = authorRepository.findByAuthorName(interestAuthorCreatRequest.getAuthorName())
+        Author author = authorRepository.findByAuthorName(interestAuthorRequest.getAuthorName())
                 .orElseThrow(() -> new AuthorNotFoundException(MemberErrorCode.NOT_FOUND_AUTHOR));
 
         // 작가의 아이디와 멤버 uid 전달하기
         InterestAuthorId newInterestAuthorId =
-                new InterestAuthorId(author.getAuthorId(), interestAuthorCreatRequest.getMemberUid());
+                new InterestAuthorId(author.getAuthorId(), interestAuthorRequest.getMemberUid());
 
         // 이미 관심 작가가 등록되어 있는 경우 예외 처리하기
         if(interestAuthorRepository.existsById(newInterestAuthorId)){
@@ -65,7 +65,22 @@ public class InterestAuthorService {
 
         interestAuthorRepository.save(newInterestAuthor);
 
-        return interestAuthorCreatRequest.getAuthorName();
+        return interestAuthorRequest.getAuthorName();
     }
+
+    @Transactional
+    public void deleteInterestAuthor(InterestAuthorRequest interestAuthorRequest) {
+        Author author = authorRepository.findByAuthorName(interestAuthorRequest.getAuthorName())
+                .orElseThrow(() -> new AuthorNotFoundException(MemberErrorCode.NOT_FOUND_AUTHOR));
+
+        InterestAuthorId interestAuthorId =
+                new InterestAuthorId(author.getAuthorId(), interestAuthorRequest.getMemberUid());
+
+        InterestAuthor interestAuthor = interestAuthorRepository.findById(interestAuthorId)
+                .orElseThrow(() -> new AuthorNotFoundException(MemberErrorCode.NOT_REGIST_AUTHOR));
+
+        interestAuthorRepository.delete(interestAuthor);
+    }
+
 
 }

--- a/src/main/java/com/jamjam/bookjeok/exception/member/MemberErrorCode.java
+++ b/src/main/java/com/jamjam/bookjeok/exception/member/MemberErrorCode.java
@@ -13,7 +13,8 @@ public enum MemberErrorCode {
     MEMBER_SEARCH_CONDITION_MISSING("1002", "memberId 또는 nickname 중 하나는 필수입니다", HttpStatus.BAD_REQUEST),
     NOT_FOUND_AUTHOR("1003", "존재하지 않는 작가입니다.", HttpStatus.NOT_FOUND),
     ALREADY_INTERESTED_AUTHOR("1004", "이미 즐겨찾기에 추가한 작가입니다.", HttpStatus.ALREADY_REPORTED),
-    INTEREST_AUTHOR_LIMIT_EXCEEDED("1005","관심 작가는 최대 30명까지 등록할 수 있습니다.", HttpStatus.TOO_MANY_REQUESTS);
+    INTEREST_AUTHOR_LIMIT_EXCEEDED("1005","관심 작가는 최대 30명까지 등록할 수 있습니다.", HttpStatus.TOO_MANY_REQUESTS),
+    NOT_REGIST_AUTHOR("1006", "관심 작가에 등록되어 있지 않습니다.", HttpStatus.NOT_FOUND);
 
     private final String code;
     private final String message;

--- a/src/main/resources/mappers/member/AdminMapper.xml
+++ b/src/main/resources/mappers/member/AdminMapper.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "https://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.jamjam.bookjeok.domains.member.repository.mapper.AdminMapper">
+
+    <select id="findAllMember" resultType="MemberDTO">
+        SELECT
+            member_uid,
+            member_id,
+            member_name,
+            phone_number,
+            email,
+            nickname,
+            birth_date,
+            marketing_consent,
+            role,
+            created_at,
+            modified_at,
+            activity_status
+        FROM members
+        WHERE role = 'MEMBER'
+        ORDER BY member_uid DESC
+        LIMIT #{ limit } OFFSET #{ offset }
+    </select>
+
+    <select id="countMembers" resultType="_long">
+        SELECT COUNT(*)
+        FROM members
+        WHERE role = 'MEMBER'
+    </select>
+</mapper>

--- a/src/test/java/com/jamjam/bookjeok/domains/member/controller/AdminControllerTest.java
+++ b/src/test/java/com/jamjam/bookjeok/domains/member/controller/AdminControllerTest.java
@@ -1,0 +1,39 @@
+package com.jamjam.bookjeok.domains.member.controller;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+@Transactional
+class AdminControllerTest {
+
+    @Autowired
+    MockMvc mockMvc;
+
+@DisplayName("멤버 전체 조회 테스트")
+    @Test
+    void getAllMembersTest() throws Exception {
+        mockMvc.perform(get("/api/v1/admin/members"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.memberList").isArray())
+                .andExpect(jsonPath("$.timestamp").exists())
+                .andDo(print());
+    }
+}
+

--- a/src/test/java/com/jamjam/bookjeok/domains/member/controller/InterestAuthorControllerTest.java
+++ b/src/test/java/com/jamjam/bookjeok/domains/member/controller/InterestAuthorControllerTest.java
@@ -1,7 +1,7 @@
 package com.jamjam.bookjeok.domains.member.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.jamjam.bookjeok.domains.member.dto.request.InterestAuthorCreatRequest;
+import com.jamjam.bookjeok.domains.member.dto.request.InterestAuthorRequest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -13,6 +13,7 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.transaction.annotation.Transactional;
 
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
@@ -44,10 +45,10 @@ public class InterestAuthorControllerTest {
                 .andDo(print());
     }
 
-    @DisplayName("즐겨찾기 등록하기")
+    @DisplayName("관심 작가 등록하기")
     @Test
     void createInterestAuthorTest() throws Exception {
-        InterestAuthorCreatRequest request = new InterestAuthorCreatRequest("공지영", 2L);
+        InterestAuthorRequest request = new InterestAuthorRequest("공지영", 2L);
 
         mockMvc.perform(post("/api/v1/interest-author")
                         .contentType(MediaType.APPLICATION_JSON)
@@ -56,6 +57,17 @@ public class InterestAuthorControllerTest {
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.data.authorName").value("공지영"))
                 .andReturn();
+    }
+
+    @DisplayName("관심 작가 삭제하기")
+    @Test
+    void deleteInterestAuthorTest() throws Exception {
+        InterestAuthorRequest request = new InterestAuthorRequest("정약용", 2L);
+
+        mockMvc.perform(delete("/api/v1/interest-author")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(jsonPath("$.success").value(true));
     }
 
 }

--- a/src/test/java/com/jamjam/bookjeok/domains/member/repository/mapper/AdminMapperTest.java
+++ b/src/test/java/com/jamjam/bookjeok/domains/member/repository/mapper/AdminMapperTest.java
@@ -1,0 +1,43 @@
+package com.jamjam.bookjeok.domains.member.repository.mapper;
+
+import com.jamjam.bookjeok.domains.member.dto.request.PageRequest;
+import com.jamjam.bookjeok.domains.member.dto.request.MemberSearchRequest;
+import com.jamjam.bookjeok.domains.member.dto.MemberDTO;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@ActiveProfiles("test")
+@SpringBootTest
+class AdminMapperTest {
+
+    @Autowired
+    private AdminMapper adminMapper;
+
+    private PageRequest pageRequest;
+
+    @DisplayName("findAllMember 테스트")
+    @Test
+    void findAllMemberTest(){
+        pageRequest = new PageRequest();
+
+        List<MemberDTO> members = adminMapper.findAllMember(pageRequest);
+
+        assertNotNull(members);
+        members.forEach(System.out::println);
+    }
+
+    @DisplayName("전체 멤버 인원 조회 테스트")
+    @Test
+    void countAllMember(){
+        long count = adminMapper.countMembers();
+        assertEquals(7, count);
+    }
+}

--- a/src/test/java/com/jamjam/bookjeok/domains/member/repository/mapper/InterestAuthorMapperTest.java
+++ b/src/test/java/com/jamjam/bookjeok/domains/member/repository/mapper/InterestAuthorMapperTest.java
@@ -38,7 +38,7 @@ class InterestAuthorMapperTest {
 
         int totalInterestAuthor = interestAuthorMapper.countInterestAuthor(memberUid);
 
-        assertEquals(3, totalInterestAuthor);
+        assertEquals(2, totalInterestAuthor);
     }
 
 }

--- a/src/test/java/com/jamjam/bookjeok/domains/member/service/AdminServiceTest.java
+++ b/src/test/java/com/jamjam/bookjeok/domains/member/service/AdminServiceTest.java
@@ -1,0 +1,88 @@
+package com.jamjam.bookjeok.domains.member.service;
+
+import com.jamjam.bookjeok.domains.member.dto.request.PageRequest;
+import com.jamjam.bookjeok.domains.member.dto.request.MemberSearchRequest;
+import com.jamjam.bookjeok.domains.member.dto.MemberDTO;
+import com.jamjam.bookjeok.domains.member.dto.response.MemberDetailResponse;
+import com.jamjam.bookjeok.domains.member.dto.response.MemberListResponse;
+import com.jamjam.bookjeok.domains.member.entity.Member;
+import com.jamjam.bookjeok.domains.member.entity.MemberRole;
+import com.jamjam.bookjeok.domains.member.repository.mapper.AdminMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ActiveProfiles("test")
+@ExtendWith(MockitoExtension.class)
+class AdminServiceTest {
+
+    @Mock
+    private AdminMapper adminMapper;
+
+    @InjectMocks
+    private AdminService adminService;
+
+    @DisplayName("findAllMember 서비스 단위 테스트")
+    @Test
+    void getAllMemberTest() {
+        // given
+        PageRequest request = new PageRequest();
+
+        MemberDTO member1 = new MemberDTO(
+                1L,
+                "user01",
+                "홍길동",
+                "01012345678",
+                "test1@gmail.com",
+                "닉네임01",
+                "19970816",
+                true,
+                MemberRole.MEMBER,
+                LocalDateTime.of(2025, 4, 6, 11, 13, 40),
+                LocalDateTime.of(2025, 4, 7, 11, 30, 40),
+                "ACTIVE"
+        );
+
+        MemberDTO member2 = new MemberDTO(
+                2L,
+                "user02",
+                "유형진",
+                "01024001349",
+                "test2@gmail.com",
+                "닉네임02",
+                "19970918",
+                true,
+                MemberRole.MEMBER,
+                LocalDateTime.of(2025, 2, 6, 14, 13, 32),
+                null,
+                "DEACTIVATE"
+        );
+
+
+        List<MemberDTO> fakeMembers = Arrays.asList(member1, member2);
+
+        when(adminMapper.findAllMember(request)).thenReturn(fakeMembers);
+        when(adminMapper.countMembers()).thenReturn(2L);
+
+        long totalItems = adminMapper.countMembers();
+        int page = request.getPage();
+        int size = request.getSize();
+
+        MemberListResponse response = adminService.getAllMembers(request);
+
+        assertNotNull(response);
+        assertEquals(2, response.getMemberList().size());
+        response.getMemberList().forEach(System.out::println);
+    }
+}

--- a/src/test/java/com/jamjam/bookjeok/domains/member/service/InterestAuthorServiceTest.java
+++ b/src/test/java/com/jamjam/bookjeok/domains/member/service/InterestAuthorServiceTest.java
@@ -1,7 +1,7 @@
 package com.jamjam.bookjeok.domains.member.service;
 
 import com.jamjam.bookjeok.domains.member.dto.InterestAuthorDTO;
-import com.jamjam.bookjeok.domains.member.dto.request.InterestAuthorCreatRequest;
+import com.jamjam.bookjeok.domains.member.dto.request.InterestAuthorRequest;
 import com.jamjam.bookjeok.exception.member.interestAuthorException.AlreadyInterestedAuthorException;
 import com.jamjam.bookjeok.exception.member.interestAuthorException.AuthorNotFoundException;
 import com.jamjam.bookjeok.exception.member.interestAuthorException.InterestAuthorLimitExceededException;
@@ -40,11 +40,14 @@ public class InterestAuthorServiceTest {
     void createInterestAuthorTest(){
         Long memberUid = 2L;
 
-        String authorName1 = "공지영";
-        InterestAuthorCreatRequest request1 = new InterestAuthorCreatRequest(authorName1, memberUid);
-        String response = interestAuthorService.createInterestAuthor(request1);
-        assertEquals("공지영", response);
+        String authorName = "공지영";
+        InterestAuthorRequest request = new InterestAuthorRequest(authorName, memberUid);
+        String response = interestAuthorService.createInterestAuthor(request);
 
+        assertEquals("공지영", response);
+        assertThrows(AlreadyInterestedAuthorException.class, () -> {
+            interestAuthorService.createInterestAuthor(request);
+        });
     }
 
     @DisplayName("관심 작가 등록시 작가가 없는 경우 예외 테스트")
@@ -52,35 +55,24 @@ public class InterestAuthorServiceTest {
     void createInterestAuthorExceptionTest1(){
         Long memberUid = 2L;
 
-        String authorName2 = "정유진";
-        InterestAuthorCreatRequest request2 = new InterestAuthorCreatRequest(authorName2, memberUid);
+        String authorName = "정유진";
+        InterestAuthorRequest request2 = new InterestAuthorRequest(authorName, memberUid);
         assertThrows(AuthorNotFoundException.class, () -> {
             interestAuthorService.createInterestAuthor(request2);
         });
     }
 
-    @DisplayName("관심 작가 등록시 이미 등록 된 작가인 경우 예외 테스트")
+    @DisplayName("관심 작가 삭제하기")
     @Test
-    void createInterestAuthorExceptionTest2(){
+    void deleteInterestAuthorTest(){
         Long memberUid = 2L;
+        String authorName = "한강";
 
-        String authorName3 = "정약용";
-        InterestAuthorCreatRequest request3 = new InterestAuthorCreatRequest(authorName3, memberUid);
-        assertThrows(AlreadyInterestedAuthorException.class, () -> {
-            interestAuthorService.createInterestAuthor(request3);
+        InterestAuthorRequest request = new InterestAuthorRequest(authorName, memberUid);
+        interestAuthorService.deleteInterestAuthor(request);
+
+        assertThrows(AuthorNotFoundException.class, () -> {
+            interestAuthorService.deleteInterestAuthor(request);
         });
     }
-
-    @DisplayName("관심자가 30명 초과시 발생하는 예외 테스트")
-    @Test
-    void interestAuthorLimitTest(){
-        Long memberUid = 2L;
-
-        String authorName3 = "정약용";
-        InterestAuthorCreatRequest request3 = new InterestAuthorCreatRequest(authorName3, memberUid);
-        assertThrows(InterestAuthorLimitExceededException.class, () -> {
-            interestAuthorService.createInterestAuthor(request3);
-        });
-    }
-
 }


### PR DESCRIPTION
⭐회원 전체 목록 조회 기능 구현하기

✅내용
- `AdminController` 작성
   -  "/api/v1/admin/members" 요청이 들어오면 전체 멤버를 가져옴
   - 페이징 처리를 위한 `PageRequest` 생성 후 파라미터로 받기
   - `AdminControllerTest` 완료
- `AdminService` 작성
   -  멤버의 전체 수를 조회하고 페이지를 전달하기 (`MemebeListResponse`)
   - `AdminServiceTest` 완료
- `AdminMapper` 작성 
   - `AdminMapper.java`와 `AdminMapper.xml` 파일 작성 완료
   -  role이 Member인 회원의 목록 가져오는 쿼리문 작성 완료
   -  페이징 처리를 위해 회원의 전체 인원을 가져오는 쿼리문 작성
   - `AdminMapperTest` 완료
