### PR TITLE
[FEATURE] 회원 전체 목록 조회 기능 구현

### DIFF
--- a/src/main/java/com/jamjam/bookjeok/domains/member/controller/AdminController.java
+++ b/src/main/java/com/jamjam/bookjeok/domains/member/controller/AdminController.java
@@ -1,0 +1,36 @@
+package com.jamjam.bookjeok.domains.member.controller;
+
+import com.jamjam.bookjeok.common.dto.ApiResponse;
+import com.jamjam.bookjeok.domains.member.dto.request.PageRequest;
+import com.jamjam.bookjeok.domains.member.dto.request.MemberSearchRequest;
+import com.jamjam.bookjeok.domains.member.dto.response.MemberDetailResponse;
+import com.jamjam.bookjeok.domains.member.dto.response.MemberListResponse;
+import com.jamjam.bookjeok.domains.member.service.AdminService;
+import com.jamjam.bookjeok.exception.member.MemberErrorCode;
+import com.jamjam.bookjeok.exception.member.MemberException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1")
+@RequiredArgsConstructor
+@Slf4j
+public class AdminController {
+
+    private final AdminService adminService;
+
+    @GetMapping("/admin/members")
+    public ResponseEntity<ApiResponse<MemberListResponse>> getAllMembers(
+            @Validated PageRequest pageRequest
+    ){
+        MemberListResponse response = adminService.getAllMembers(pageRequest);
+
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+}

--- a/src/main/java/com/jamjam/bookjeok/domains/member/dto/request/PageRequest.java
+++ b/src/main/java/com/jamjam/bookjeok/domains/member/dto/request/PageRequest.java
@@ -1,0 +1,25 @@
+package com.jamjam.bookjeok.domains.member.dto.request;
+
+import jakarta.validation.constraints.Min;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class PageRequest {
+
+    @Min(value = 1)
+    private Integer page = 1;
+
+    @Min(value = 1)
+    private Integer size = 10;
+
+    public int getOffset(){
+        return (page-1) * size;
+    }
+
+    public int getLimit(){
+        return size;
+    }
+}

--- a/src/main/java/com/jamjam/bookjeok/domains/member/dto/request/PageRequest.java
+++ b/src/main/java/com/jamjam/bookjeok/domains/member/dto/request/PageRequest.java
@@ -1,19 +1,21 @@
 package com.jamjam.bookjeok.domains.member.dto.request;
 
 import jakarta.validation.constraints.Min;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.Setter;
+import lombok.*;
 
 @Getter
-@Setter
 public class PageRequest {
 
     @Min(value = 1)
-    private Integer page = 1;
+    private Integer page;
 
     @Min(value = 1)
-    private Integer size = 10;
+    private Integer size;
+
+    public PageRequest(Integer page, Integer size) {
+        this.page = (page == null) ? 1 : page;
+        this.size = (size == null) ? 10 : size;
+    }
 
     public int getOffset(){
         return (page-1) * size;

--- a/src/main/java/com/jamjam/bookjeok/domains/member/dto/response/MemberListResponse.java
+++ b/src/main/java/com/jamjam/bookjeok/domains/member/dto/response/MemberListResponse.java
@@ -1,0 +1,17 @@
+package com.jamjam.bookjeok.domains.member.dto.response;
+
+import com.jamjam.bookjeok.common.dto.Pagination;
+import com.jamjam.bookjeok.domains.member.dto.MemberDTO;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class MemberListResponse {
+
+    private List<MemberDTO> memberList;
+    private final Pagination pagination;
+
+}

--- a/src/main/java/com/jamjam/bookjeok/domains/member/repository/mapper/AdminMapper.java
+++ b/src/main/java/com/jamjam/bookjeok/domains/member/repository/mapper/AdminMapper.java
@@ -1,0 +1,17 @@
+package com.jamjam.bookjeok.domains.member.repository.mapper;
+
+import com.jamjam.bookjeok.domains.member.dto.request.PageRequest;
+import com.jamjam.bookjeok.domains.member.dto.request.MemberSearchRequest;
+import com.jamjam.bookjeok.domains.member.dto.MemberDTO;
+import org.apache.ibatis.annotations.Mapper;
+
+import java.util.List;
+
+@Mapper
+public interface AdminMapper {
+
+    List<MemberDTO> findAllMember(PageRequest pageRequest);
+
+    long countMembers();
+
+}

--- a/src/main/java/com/jamjam/bookjeok/domains/member/service/AdminService.java
+++ b/src/main/java/com/jamjam/bookjeok/domains/member/service/AdminService.java
@@ -1,0 +1,45 @@
+package com.jamjam.bookjeok.domains.member.service;
+
+import com.jamjam.bookjeok.common.dto.Pagination;
+import com.jamjam.bookjeok.domains.member.dto.request.PageRequest;
+import com.jamjam.bookjeok.domains.member.dto.request.MemberSearchRequest;
+import com.jamjam.bookjeok.domains.member.dto.MemberDTO;
+import com.jamjam.bookjeok.domains.member.dto.response.MemberDetailResponse;
+import com.jamjam.bookjeok.domains.member.dto.response.MemberListResponse;
+import com.jamjam.bookjeok.domains.member.repository.mapper.AdminMapper;
+import com.jamjam.bookjeok.exception.member.MemberErrorCode;
+import com.jamjam.bookjeok.exception.member.MemberException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class AdminService {
+
+    private final AdminMapper adminMapper;
+
+    // 멤버의 전체 목록을 조회하는 기능
+    @Transactional(readOnly = true)
+    public MemberListResponse getAllMembers(PageRequest pageRequest) {
+        List<MemberDTO> members = adminMapper.findAllMember(pageRequest);
+
+        // 페이징 처리를 위해 전체 멤버의 수 조회하기
+        long totalItems = adminMapper.countMembers();
+
+        int page = pageRequest.getPage();
+        int size = pageRequest.getSize();
+
+        return MemberListResponse.builder()
+                .memberList(members)
+                .pagination(Pagination.builder()
+                    .currentPage(page)
+                    .totalPage((int)Math.ceil((double)totalItems/size))
+                    .totalItems(totalItems)
+                    .build())
+                .build();
+    }
+}

--- a/src/main/resources/mappers/member/AdminMapper.xml
+++ b/src/main/resources/mappers/member/AdminMapper.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "https://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.jamjam.bookjeok.domains.member.repository.mapper.AdminMapper">
+
+    <select id="findAllMember" resultType="MemberDTO">
+        SELECT
+            member_uid,
+            member_id,
+            member_name,
+            phone_number,
+            email,
+            nickname,
+            birth_date,
+            marketing_consent,
+            role,
+            created_at,
+            modified_at,
+            activity_status
+        FROM members
+        WHERE role = 'MEMBER'
+        ORDER BY member_uid DESC
+        LIMIT #{ limit } OFFSET #{ offset }
+    </select>
+
+    <select id="countMembers" resultType="_long">
+        SELECT COUNT(*)
+        FROM members
+        WHERE role = 'MEMBER'
+    </select>
+</mapper>

--- a/src/main/resources/mappers/member/AdminMapper.xml
+++ b/src/main/resources/mappers/member/AdminMapper.xml
@@ -20,7 +20,7 @@
             activity_status
         FROM members
         WHERE role = 'MEMBER'
-        ORDER BY member_uid DESC
+        ORDER BY member_uid
         LIMIT #{ limit } OFFSET #{ offset }
     </select>
 

--- a/src/test/java/com/jamjam/bookjeok/domains/member/controller/AdminControllerTest.java
+++ b/src/test/java/com/jamjam/bookjeok/domains/member/controller/AdminControllerTest.java
@@ -1,0 +1,39 @@
+package com.jamjam.bookjeok.domains.member.controller;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+@Transactional
+class AdminControllerTest {
+
+    @Autowired
+    MockMvc mockMvc;
+
+@DisplayName("멤버 전체 조회 테스트")
+    @Test
+    void getAllMembersTest() throws Exception {
+        mockMvc.perform(get("/api/v1/admin/members"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.memberList").isArray())
+                .andExpect(jsonPath("$.timestamp").exists())
+                .andDo(print());
+    }
+}
+

--- a/src/test/java/com/jamjam/bookjeok/domains/member/controller/AdminControllerTest.java
+++ b/src/test/java/com/jamjam/bookjeok/domains/member/controller/AdminControllerTest.java
@@ -25,7 +25,7 @@ class AdminControllerTest {
     @Autowired
     MockMvc mockMvc;
 
-@DisplayName("멤버 전체 조회 테스트")
+    @DisplayName("멤버 전체 조회 테스트")
     @Test
     void getAllMembersTest() throws Exception {
         mockMvc.perform(get("/api/v1/admin/members"))

--- a/src/test/java/com/jamjam/bookjeok/domains/member/repository/mapper/AdminMapperTest.java
+++ b/src/test/java/com/jamjam/bookjeok/domains/member/repository/mapper/AdminMapperTest.java
@@ -1,0 +1,43 @@
+package com.jamjam.bookjeok.domains.member.repository.mapper;
+
+import com.jamjam.bookjeok.domains.member.dto.request.PageRequest;
+import com.jamjam.bookjeok.domains.member.dto.request.MemberSearchRequest;
+import com.jamjam.bookjeok.domains.member.dto.MemberDTO;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@ActiveProfiles("test")
+@SpringBootTest
+class AdminMapperTest {
+
+    @Autowired
+    private AdminMapper adminMapper;
+
+    private PageRequest pageRequest;
+
+    @DisplayName("findAllMember 테스트")
+    @Test
+    void findAllMemberTest(){
+        pageRequest = new PageRequest();
+
+        List<MemberDTO> members = adminMapper.findAllMember(pageRequest);
+
+        assertNotNull(members);
+        members.forEach(System.out::println);
+    }
+
+    @DisplayName("전체 멤버 인원 조회 테스트")
+    @Test
+    void countAllMember(){
+        long count = adminMapper.countMembers();
+        assertEquals(7, count);
+    }
+}

--- a/src/test/java/com/jamjam/bookjeok/domains/member/repository/mapper/AdminMapperTest.java
+++ b/src/test/java/com/jamjam/bookjeok/domains/member/repository/mapper/AdminMapperTest.java
@@ -26,7 +26,7 @@ class AdminMapperTest {
     @DisplayName("findAllMember 테스트")
     @Test
     void findAllMemberTest(){
-        pageRequest = new PageRequest();
+        pageRequest = new PageRequest(1,10);
 
         List<MemberDTO> members = adminMapper.findAllMember(pageRequest);
 

--- a/src/test/java/com/jamjam/bookjeok/domains/member/service/AdminServiceTest.java
+++ b/src/test/java/com/jamjam/bookjeok/domains/member/service/AdminServiceTest.java
@@ -1,0 +1,88 @@
+package com.jamjam.bookjeok.domains.member.service;
+
+import com.jamjam.bookjeok.domains.member.dto.request.PageRequest;
+import com.jamjam.bookjeok.domains.member.dto.request.MemberSearchRequest;
+import com.jamjam.bookjeok.domains.member.dto.MemberDTO;
+import com.jamjam.bookjeok.domains.member.dto.response.MemberDetailResponse;
+import com.jamjam.bookjeok.domains.member.dto.response.MemberListResponse;
+import com.jamjam.bookjeok.domains.member.entity.Member;
+import com.jamjam.bookjeok.domains.member.entity.MemberRole;
+import com.jamjam.bookjeok.domains.member.repository.mapper.AdminMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ActiveProfiles("test")
+@ExtendWith(MockitoExtension.class)
+class AdminServiceTest {
+
+    @Mock
+    private AdminMapper adminMapper;
+
+    @InjectMocks
+    private AdminService adminService;
+
+    @DisplayName("findAllMember 서비스 단위 테스트")
+    @Test
+    void getAllMemberTest() {
+        // given
+        PageRequest request = new PageRequest();
+
+        MemberDTO member1 = new MemberDTO(
+                1L,
+                "user01",
+                "홍길동",
+                "01012345678",
+                "test1@gmail.com",
+                "닉네임01",
+                "19970816",
+                true,
+                MemberRole.MEMBER,
+                LocalDateTime.of(2025, 4, 6, 11, 13, 40),
+                LocalDateTime.of(2025, 4, 7, 11, 30, 40),
+                "ACTIVE"
+        );
+
+        MemberDTO member2 = new MemberDTO(
+                2L,
+                "user02",
+                "유형진",
+                "01024001349",
+                "test2@gmail.com",
+                "닉네임02",
+                "19970918",
+                true,
+                MemberRole.MEMBER,
+                LocalDateTime.of(2025, 2, 6, 14, 13, 32),
+                null,
+                "DEACTIVATE"
+        );
+
+
+        List<MemberDTO> fakeMembers = Arrays.asList(member1, member2);
+
+        when(adminMapper.findAllMember(request)).thenReturn(fakeMembers);
+        when(adminMapper.countMembers()).thenReturn(2L);
+
+        long totalItems = adminMapper.countMembers();
+        int page = request.getPage();
+        int size = request.getSize();
+
+        MemberListResponse response = adminService.getAllMembers(request);
+
+        assertNotNull(response);
+        assertEquals(2, response.getMemberList().size());
+        response.getMemberList().forEach(System.out::println);
+    }
+}

--- a/src/test/java/com/jamjam/bookjeok/domains/member/service/AdminServiceTest.java
+++ b/src/test/java/com/jamjam/bookjeok/domains/member/service/AdminServiceTest.java
@@ -36,8 +36,7 @@ class AdminServiceTest {
     @DisplayName("findAllMember 서비스 단위 테스트")
     @Test
     void getAllMemberTest() {
-        // given
-        PageRequest request = new PageRequest();
+        PageRequest request = new PageRequest(1,10);
 
         MemberDTO member1 = new MemberDTO(
                 1L,


### PR DESCRIPTION
⭐회원 전체 목록 조회 기능 구현하기

✅내용
- `AdminController` 작성
   -  "/api/v1/admin/members" 요청이 들어오면 전체 멤버를 가져옴
   - 페이징 처리를 위한 `PageRequest` 생성 후 파라미터로 받기
   - `AdminControllerTest` 완료
- `AdminService` 작성
   -  멤버의 전체 수를 조회하고 페이지를 전달하기 (`MemebeListResponse`)
   - `AdminServiceTest` 완료
- `AdminMapper` 작성 
   - `AdminMapper.java`와 `AdminMapper.xml` 파일 작성 완료
   -  role이 Member인 회원의 목록 가져오는 쿼리문 작성 완료
   -  페이징 처리를 위해 회원의 전체 인원을 가져오는 쿼리문 작성
   - `AdminMapperTest` 완료
