### PR TITLE
[FEATURE] 팔로우 하기 기능 구현하기

### DIFF
--- a/src/main/java/com/jamjam/bookjeok/domains/member/controller/FollowController.java
+++ b/src/main/java/com/jamjam/bookjeok/domains/member/controller/FollowController.java
@@ -6,7 +6,6 @@ import com.jamjam.bookjeok.domains.member.dto.PostSummaryDTO;
 import com.jamjam.bookjeok.domains.member.dto.request.FollowMemberRequest;
 import com.jamjam.bookjeok.domains.member.dto.response.FollowMemberResponse;
 import com.jamjam.bookjeok.domains.member.service.FollowService;
-import jakarta.validation.constraints.NotNull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;

--- a/src/main/java/com/jamjam/bookjeok/domains/member/controller/FollowController.java
+++ b/src/main/java/com/jamjam/bookjeok/domains/member/controller/FollowController.java
@@ -3,19 +3,23 @@ package com.jamjam.bookjeok.domains.member.controller;
 import com.jamjam.bookjeok.common.dto.ApiResponse;
 import com.jamjam.bookjeok.domains.member.dto.FollowDTO;
 import com.jamjam.bookjeok.domains.member.dto.PostSummaryDTO;
+import com.jamjam.bookjeok.domains.member.dto.request.FollowMemberRequest;
+import com.jamjam.bookjeok.domains.member.dto.response.FollowMemberResponse;
 import com.jamjam.bookjeok.domains.member.service.FollowService;
+import jakarta.validation.constraints.NotNull;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1")
+@Slf4j
 public class FollowController {
 
     private final FollowService followService;
@@ -37,5 +41,28 @@ public class FollowController {
 
         return ResponseEntity.ok(ApiResponse.success(postList));
 
+    }
+
+    // 로그인 끝나면 이 부분 수정하기
+    @PostMapping("/{followerId}/follow")
+    public ResponseEntity<ApiResponse<FollowMemberResponse>> createFollow(
+            @RequestBody @Validated FollowMemberRequest followMemberRequest,
+            @PathVariable String followerId
+    ){
+
+        String followingId = followMemberRequest.getFollowingId();
+
+        log.info("followerId : {}", followerId);
+        log.info("followingId : {}", followingId);
+
+        String nickname = followService.createFollow(followingId, followerId);
+
+        FollowMemberResponse response = FollowMemberResponse.builder()
+                .nickname(nickname)
+                .build();
+
+        return ResponseEntity
+                .status(HttpStatus.CREATED)
+                .body(ApiResponse.success(response));
     }
 }

--- a/src/main/java/com/jamjam/bookjeok/domains/member/dto/request/FollowMemberRequest.java
+++ b/src/main/java/com/jamjam/bookjeok/domains/member/dto/request/FollowMemberRequest.java
@@ -1,0 +1,14 @@
+package com.jamjam.bookjeok.domains.member.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class FollowMemberRequest {
+
+    @NotNull(message = "팔로워의 아이디는 비어 있을 수 없습니다.")
+    private final String followingId;
+
+}

--- a/src/main/java/com/jamjam/bookjeok/domains/member/dto/response/FollowMemberResponse.java
+++ b/src/main/java/com/jamjam/bookjeok/domains/member/dto/response/FollowMemberResponse.java
@@ -1,0 +1,13 @@
+package com.jamjam.bookjeok.domains.member.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class FollowMemberResponse {
+
+    private String nickname;
+
+}
+

--- a/src/main/java/com/jamjam/bookjeok/domains/member/entity/Follow.java
+++ b/src/main/java/com/jamjam/bookjeok/domains/member/entity/Follow.java
@@ -16,16 +16,16 @@ public class Follow {
     @Column(name = "follow_id")
     private Long followId;
 
-    @Column(name = "following_id")
-    private Long followingId;
+    @Column(name = "following_uid")
+    private Long followingUid;
 
-    @Column(name = "follower_id")
-    private Long followerId;
+    @Column(name = "follower_uid")
+    private Long followerUid;
 
     @Builder
-    public Follow(Long followingId, Long followerId) {
-        this.followingId = followingId;
-        this.followerId = followerId;
+    public Follow(Long followingUid, Long followerUid) {
+        this.followingUid = followingUid;
+        this.followerUid = followerUid;
     }
 
 }

--- a/src/main/java/com/jamjam/bookjeok/domains/member/repository/repository/FollowRepository.java
+++ b/src/main/java/com/jamjam/bookjeok/domains/member/repository/repository/FollowRepository.java
@@ -1,0 +1,12 @@
+package com.jamjam.bookjeok.domains.member.repository.repository;
+
+import com.jamjam.bookjeok.domains.member.entity.Follow;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface FollowRepository extends JpaRepository<Follow,Long> {
+
+    boolean existsByFollowingUidAndFollowerUid(Long followingUid, Long followerUid);
+
+}

--- a/src/main/java/com/jamjam/bookjeok/domains/member/repository/repository/MemberRepository.java
+++ b/src/main/java/com/jamjam/bookjeok/domains/member/repository/repository/MemberRepository.java
@@ -1,0 +1,14 @@
+package com.jamjam.bookjeok.domains.member.repository.repository;
+
+import com.jamjam.bookjeok.domains.member.entity.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface MemberRepository extends JpaRepository<Member, Long>{
+
+    Optional<Member> findByMemberId(String memberId);
+
+}

--- a/src/main/java/com/jamjam/bookjeok/domains/member/service/FollowService.java
+++ b/src/main/java/com/jamjam/bookjeok/domains/member/service/FollowService.java
@@ -2,13 +2,11 @@ package com.jamjam.bookjeok.domains.member.service;
 
 import com.jamjam.bookjeok.domains.member.dto.FollowDTO;
 import com.jamjam.bookjeok.domains.member.dto.PostSummaryDTO;
-import com.jamjam.bookjeok.domains.member.dto.request.InterestAuthorRequest;
 import com.jamjam.bookjeok.domains.member.entity.Follow;
 import com.jamjam.bookjeok.domains.member.entity.Member;
 import com.jamjam.bookjeok.domains.member.repository.mapper.FollowMapper;
 import com.jamjam.bookjeok.domains.member.repository.repository.FollowRepository;
 import com.jamjam.bookjeok.domains.member.repository.repository.MemberRepository;
-import com.jamjam.bookjeok.exception.coupon.ErrorCode;
 import com.jamjam.bookjeok.exception.member.MemberErrorCode;
 import com.jamjam.bookjeok.exception.member.MemberException;
 import com.jamjam.bookjeok.exception.member.followException.AlreadyFollowException;

--- a/src/main/java/com/jamjam/bookjeok/domains/member/service/FollowService.java
+++ b/src/main/java/com/jamjam/bookjeok/domains/member/service/FollowService.java
@@ -2,8 +2,18 @@ package com.jamjam.bookjeok.domains.member.service;
 
 import com.jamjam.bookjeok.domains.member.dto.FollowDTO;
 import com.jamjam.bookjeok.domains.member.dto.PostSummaryDTO;
+import com.jamjam.bookjeok.domains.member.dto.request.InterestAuthorRequest;
+import com.jamjam.bookjeok.domains.member.entity.Follow;
+import com.jamjam.bookjeok.domains.member.entity.Member;
 import com.jamjam.bookjeok.domains.member.repository.mapper.FollowMapper;
+import com.jamjam.bookjeok.domains.member.repository.repository.FollowRepository;
+import com.jamjam.bookjeok.domains.member.repository.repository.MemberRepository;
+import com.jamjam.bookjeok.exception.coupon.ErrorCode;
+import com.jamjam.bookjeok.exception.member.MemberErrorCode;
+import com.jamjam.bookjeok.exception.member.MemberException;
+import com.jamjam.bookjeok.exception.member.followException.AlreadyFollowException;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -11,9 +21,12 @@ import java.util.List;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class FollowService {
 
     private final FollowMapper followMapper;
+    private final FollowRepository followRepository;
+    private final MemberRepository memberRepository;
 
     @Transactional(readOnly = true)
     public List<FollowDTO> getFollowingListByMemberId(String memberId) {
@@ -23,5 +36,46 @@ public class FollowService {
     @Transactional(readOnly = true)
     public List<PostSummaryDTO> getPostListByWriterId(String writerId) {
         return followMapper.findPostListByMemberId(writerId);
+    }
+
+    @Transactional
+    public String createFollow(String followingId, String followerId){
+
+        // followerId를 통해 팔로워 하는 사람의 Uid 가져오기 (나중에 변경할 예정)
+        Member follower = memberRepository.findByMemberId(followerId)
+                .orElseThrow(() -> {
+                    log.error("팔로워 ID {} 찾을 수 없음", followerId);
+                    return new MemberException(MemberErrorCode.NOT_EXIST_MEMBER);
+                });
+
+        // 팔로잉 하고자 하는 사람
+        Member following = memberRepository.findByMemberId(followingId)
+                .orElseThrow(() -> {
+                    log.error("팔로워 ID {} 찾을 수 없음", followingId);
+                    return new MemberException(MemberErrorCode.NOT_EXIST_MEMBER);
+                });
+
+        // 각각의 사람들의 uid 가져오기
+        Long followerUid = follower.getMemberUid();
+        Long followingUid = following.getMemberUid();
+
+        log.info("팔로우 관계 확인: followerUid = {}, followingUid = {}", followerUid, followingUid);
+        boolean isAlreadyFollowing = isFollowing(followingUid, followerUid);
+        log.info("팔로우 관계 존재 여부: {}", isAlreadyFollowing);
+
+        // 팔로우를 하고 있는 사람이라면 예외 처리
+        if(isFollowing(followingUid, followerUid)) {
+            throw new AlreadyFollowException(MemberErrorCode.ALREADY_FOLLOW);
+        }
+
+        Follow follow = new Follow(followingUid, followerUid);
+
+        followRepository.save(follow);
+
+        return following.getNickname();
+    }
+
+    private boolean isFollowing(Long followingUid, Long followerUid){
+        return followRepository.existsByFollowingUidAndFollowerUid(followingUid, followerUid);
     }
 }

--- a/src/main/java/com/jamjam/bookjeok/exception/member/MemberErrorCode.java
+++ b/src/main/java/com/jamjam/bookjeok/exception/member/MemberErrorCode.java
@@ -14,7 +14,8 @@ public enum MemberErrorCode {
     NOT_FOUND_AUTHOR("1003", "존재하지 않는 작가입니다.", HttpStatus.NOT_FOUND),
     ALREADY_INTERESTED_AUTHOR("1004", "이미 즐겨찾기에 추가한 작가입니다.", HttpStatus.ALREADY_REPORTED),
     INTEREST_AUTHOR_LIMIT_EXCEEDED("1005","관심 작가는 최대 30명까지 등록할 수 있습니다.", HttpStatus.TOO_MANY_REQUESTS),
-    NOT_REGIST_AUTHOR("1006", "관심 작가에 등록되어 있지 않습니다.", HttpStatus.NOT_FOUND);
+    NOT_REGIST_AUTHOR("1006", "관심 작가에 등록되어 있지 않습니다.", HttpStatus.NOT_FOUND),
+    ALREADY_FOLLOW("1007", "이미 팔로우 하고 있는 사용자 입니다.", HttpStatus.ALREADY_REPORTED);
 
     private final String code;
     private final String message;

--- a/src/main/java/com/jamjam/bookjeok/exception/member/MemberExceptionHandler.java
+++ b/src/main/java/com/jamjam/bookjeok/exception/member/MemberExceptionHandler.java
@@ -1,6 +1,7 @@
 package com.jamjam.bookjeok.exception.member;
 
 import com.jamjam.bookjeok.common.dto.ApiResponse;
+import com.jamjam.bookjeok.exception.member.followException.AlreadyFollowException;
 import com.jamjam.bookjeok.exception.member.interestAuthorException.AlreadyInterestedAuthorException;
 import com.jamjam.bookjeok.exception.member.interestAuthorException.AuthorNotFoundException;
 import org.springframework.http.ResponseEntity;
@@ -30,6 +31,15 @@ public class MemberExceptionHandler {
 
     @ExceptionHandler(AlreadyInterestedAuthorException.class)
     public ResponseEntity<ApiResponse> handleAlreadyInterestedAuthorException(AlreadyInterestedAuthorException e){
+        MemberErrorCode errorCode = e.getMemberErrorCode();
+        ApiResponse<Void> response
+                = ApiResponse.failure(errorCode.getCode(), errorCode.getMessage());
+
+        return new ResponseEntity<>(response,errorCode.getHttpStatus());
+    }
+
+    @ExceptionHandler(AlreadyFollowException.class)
+    public ResponseEntity<ApiResponse> handleAlreadyFollowException(AlreadyFollowException e){
         MemberErrorCode errorCode = e.getMemberErrorCode();
         ApiResponse<Void> response
                 = ApiResponse.failure(errorCode.getCode(), errorCode.getMessage());

--- a/src/main/java/com/jamjam/bookjeok/exception/member/followException/AlreadyFollowException.java
+++ b/src/main/java/com/jamjam/bookjeok/exception/member/followException/AlreadyFollowException.java
@@ -1,0 +1,14 @@
+package com.jamjam.bookjeok.exception.member.followException;
+
+import com.jamjam.bookjeok.exception.member.MemberErrorCode;
+import lombok.Getter;
+
+@Getter
+public class AlreadyFollowException extends RuntimeException{
+    private final MemberErrorCode memberErrorCode;
+
+    public AlreadyFollowException(MemberErrorCode memberErrorCode){
+        super(memberErrorCode.getMessage());
+        this.memberErrorCode = memberErrorCode;
+    }
+}

--- a/src/main/resources/mappers/member/FollowMapper.xml
+++ b/src/main/resources/mappers/member/FollowMapper.xml
@@ -10,7 +10,9 @@
             m.nickname
         FROM follows f
         JOIN members m ON f.following_uid = m.member_uid
-        WHERE f.follower_uid = (
+        WHERE m.activity_status = 'ACTIVE'
+        AND m.role = 'MEMBER'
+        AND f.follower_uid = (
             SELECT member_uid
             FROM members
             WHERE member_id = #{ memberId }
@@ -19,16 +21,19 @@
 
     <select id="findPostListByMemberId" resultType="PostSummaryDTO">
         SELECT
+            p.writer_uid,
             m.nickname,
             p.title
         FROM posts p
         JOIN members m ON p.writer_uid = m.member_uid
-        WHERE p.writer_uid = (
+        WHERE m.activity_status = 'ACTIVE'
+        AND m.role = 'MEMBER'
+        AND p.is_deleted = false
+        AND p.writer_uid = (
             SELECT member_uid
             FROM members
             WHERE member_id = #{ writerId }
         )
         ORDER BY p.created_at DESC
     </select>
-
 </mapper>

--- a/src/test/java/com/jamjam/bookjeok/domains/member/controller/FollowControllerTest.java
+++ b/src/test/java/com/jamjam/bookjeok/domains/member/controller/FollowControllerTest.java
@@ -3,12 +3,15 @@ package com.jamjam.bookjeok.domains.member.controller;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.jamjam.bookjeok.domains.member.dto.FollowDTO;
 import com.jamjam.bookjeok.domains.member.dto.PostSummaryDTO;
+import com.jamjam.bookjeok.domains.member.dto.request.FollowMemberRequest;
+import com.jamjam.bookjeok.domains.member.dto.request.InterestAuthorRequest;
 import com.jamjam.bookjeok.domains.member.service.FollowService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
@@ -18,6 +21,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.List;
 
 import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -34,20 +38,10 @@ class FollowControllerTest {
     @Autowired
     ObjectMapper objectMapper;
 
-    @MockitoBean
-    private FollowService followService;
-
     @DisplayName("특정 멤버의 팔로우 목록 가져오기")
     @Test
     void getFollowListByMemberUidTest() throws Exception {
         String memberId = "user01";
-
-        List<FollowDTO> mockFollowList = List.of(
-                new FollowDTO("user02", "닉네임02"),
-                new FollowDTO("user03", "닉네임03")
-        );
-
-        when(followService.getFollowingListByMemberId(memberId)).thenReturn(mockFollowList);
 
         mockMvc.perform(MockMvcRequestBuilders.get("/api/v1/{memberId}/followings", memberId))
                 .andExpect(status().isOk())
@@ -66,27 +60,33 @@ class FollowControllerTest {
     void getPostListByWriterIdTest() throws Exception {
         String writerId = "user02";
 
-        List<PostSummaryDTO> mockPostList = List.of(
-                new PostSummaryDTO("닉네임02", "제목01"),
-                new PostSummaryDTO("닉네임02", "제목02")
-        );
-
-
-        when(followService.getPostListByWriterId(writerId)).thenReturn(mockPostList);
-
         mockMvc.perform(MockMvcRequestBuilders.get("/api/v1/{writerId}/postList", writerId))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.data").isArray())
-                .andExpect(jsonPath("$.data.length()").value(2))
+                .andExpect(jsonPath("$.data.length()").value(1))
                 .andExpect(jsonPath("$.data[0].nickname").value("닉네임02"))
-                .andExpect(jsonPath("$.data[0].title").value("제목01"))
-                .andExpect(jsonPath("$.data[1].nickname").value("닉네임02"))
-                .andExpect(jsonPath("$.data[1].title").value("제목02"))
+                .andExpect(jsonPath("$.data[0].title").value("코딩 입문자"))
                 .andExpect(jsonPath("$.timestamp").exists())
                 .andDo(print());
 
     }
 
+    @DisplayName("팔로우 하기")
+    @Test
+    void createFollowTest() throws Exception {
+        String followerId = "user01";
+        String followingId = "user04";
+
+        FollowMemberRequest followMemberRequest = new FollowMemberRequest(followingId);
+
+        mockMvc.perform(post("/api/v1/{followerId}/follow", followerId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(followMemberRequest)))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.nickname").value("닉네임04"))
+                .andReturn();
+    }
 
 }

--- a/src/test/java/com/jamjam/bookjeok/domains/member/controller/FollowControllerTest.java
+++ b/src/test/java/com/jamjam/bookjeok/domains/member/controller/FollowControllerTest.java
@@ -1,11 +1,7 @@
 package com.jamjam.bookjeok.domains.member.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.jamjam.bookjeok.domains.member.dto.FollowDTO;
-import com.jamjam.bookjeok.domains.member.dto.PostSummaryDTO;
 import com.jamjam.bookjeok.domains.member.dto.request.FollowMemberRequest;
-import com.jamjam.bookjeok.domains.member.dto.request.InterestAuthorRequest;
-import com.jamjam.bookjeok.domains.member.service.FollowService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -13,14 +9,9 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.List;
-
-import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;

--- a/src/test/java/com/jamjam/bookjeok/domains/member/repository/mapper/FollowMapperTest.java
+++ b/src/test/java/com/jamjam/bookjeok/domains/member/repository/mapper/FollowMapperTest.java
@@ -10,6 +10,7 @@ import org.springframework.test.context.ActiveProfiles;
 
 import java.util.List;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 @ActiveProfiles("test")
@@ -27,7 +28,10 @@ class FollowMapperTest {
         List<FollowDTO> followingListDTO = followMapper.findFollowingListByMemberId(id);
 
         assertNotNull(followingListDTO);
-        followingListDTO.forEach(System.out::println);
+        assertEquals("user02", followingListDTO.get(0).getMemberId());
+        assertEquals("user03", followingListDTO.get(1).getMemberId());
+        assertEquals("닉네임02", followingListDTO.get(0).getNickname());
+        assertEquals("닉네임03", followingListDTO.get(1).getNickname());
     }
 
     @DisplayName("멤버의 id로 게시글 목록 가져오기")

--- a/src/test/java/com/jamjam/bookjeok/domains/member/service/FollowServiceTest.java
+++ b/src/test/java/com/jamjam/bookjeok/domains/member/service/FollowServiceTest.java
@@ -2,24 +2,17 @@ package com.jamjam.bookjeok.domains.member.service;
 
 import com.jamjam.bookjeok.domains.member.dto.FollowDTO;
 import com.jamjam.bookjeok.domains.member.dto.PostSummaryDTO;
-import com.jamjam.bookjeok.domains.member.repository.mapper.FollowMapper;
 import com.jamjam.bookjeok.exception.member.followException.AlreadyFollowException;
-import com.jamjam.bookjeok.exception.member.interestAuthorException.AuthorNotFoundException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
-
 import java.util.List;
-
-import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.when;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @ActiveProfiles("test")
 @Transactional
@@ -70,7 +63,7 @@ class FollowServiceTest {
     @Test
     void alreadyFollowExceptionTest() {
         String followerId = "user01";
-        String followingId = "user04";
+        String followingId = "user02";
 
         assertThrows(AlreadyFollowException.class, () -> {
             followService.createFollow(followingId, followerId);

--- a/src/test/java/com/jamjam/bookjeok/domains/member/service/FollowServiceTest.java
+++ b/src/test/java/com/jamjam/bookjeok/domains/member/service/FollowServiceTest.java
@@ -3,13 +3,18 @@ package com.jamjam.bookjeok.domains.member.service;
 import com.jamjam.bookjeok.domains.member.dto.FollowDTO;
 import com.jamjam.bookjeok.domains.member.dto.PostSummaryDTO;
 import com.jamjam.bookjeok.domains.member.repository.mapper.FollowMapper;
+import com.jamjam.bookjeok.exception.member.followException.AlreadyFollowException;
+import com.jamjam.bookjeok.exception.member.interestAuthorException.AuthorNotFoundException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
@@ -17,57 +22,59 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.when;
 
 @ActiveProfiles("test")
-@ExtendWith(MockitoExtension.class)
+@Transactional
+@SpringBootTest
 class FollowServiceTest {
 
-    @Mock
-    private FollowMapper followMapper;
-
-    @InjectMocks
+    @Autowired
     private FollowService followService;
 
     @DisplayName("멤버의 id 통해 팔로우 목록 가져오기")
     @Test
     void findFollowingListByMemberId() {
-        // given
-        String memberID = "user01";
-        List<FollowDTO> mockFollowList = List.of(
-                new FollowDTO("user02", "닉네임02"),
-                new FollowDTO("user03", "닉네임03")
-        );
+        String memberId = "user01";
 
-        when(followMapper.findFollowingListByMemberId(memberID)).thenReturn(mockFollowList);
+        List<FollowDTO> followList = followService.getFollowingListByMemberId(memberId);
 
-        // when
-        List<FollowDTO> followList = followService.getFollowingListByMemberId(memberID);
-
-        // then
         assertNotNull(followList);
         assertEquals(2, followList.size());
         assertEquals("user02", followList.get(0).getMemberId());
         assertEquals("닉네임02", followList.get(0).getNickname());
         assertEquals("user03", followList.get(1).getMemberId());
         assertEquals("닉네임03", followList.get(1).getNickname());
-
-        followList.forEach(System.out::println);
     }
 
 
-    @DisplayName("팔로우한 사용자의 게시글 목록 정상 조회")
+    @DisplayName("팔로우한 사용자의 게시글 목록 조회")
     @Test
     void getPostsByWriterIdTest() {
         String writerId = "user02";
 
-        List<PostSummaryDTO> mockPostList = List.of(
-                new PostSummaryDTO("닉네임02", "제목01"),
-                new PostSummaryDTO("닉네임02", "제목02")
-        );
+        List<PostSummaryDTO> postSummaryList = followService.getPostListByWriterId(writerId);
 
-
-        when(followMapper.findPostListByMemberId(writerId)).thenReturn(mockPostList);
-
-        List<PostSummaryDTO> postList = followService.getPostListByWriterId(writerId);
-
-        assertNotNull(postList);
+        assertNotNull(postSummaryList);
     }
+
+    @DisplayName("팔로잉 테스트")
+    @Test
+    void createFollowTest() {
+        String followerId = "user01";
+        String followingId = "user04";
+
+        String response = followService.createFollow(followingId, followerId);
+
+        assertEquals("닉네임04", response);
+    }
+
+    @DisplayName("이미 팔로우 목록에 있는 경우 예외 발생 시키기")
+    @Test
+    void alreadyFollowExceptionTest() {
+        String followerId = "user01";
+        String followingId = "user04";
+
+        assertThrows(AlreadyFollowException.class, () -> {
+            followService.createFollow(followingId, followerId);
+        });
+    }
+
 }


### PR DESCRIPTION
## ⭐ 팔로우 하기 기능 구현하기

## ✅ 작업한 내용
- [x] `FollowController` 작성하기
   - [x] 팔로워와 팔로잉 하는 사람의 아이디를 전달 받아서 팔로우 하기
   - [x] `FollowControllerTest` 작성하기
   - [x] 요청 객체 만들기 - `FollowMemberRequest` : 멤버의 아이디를 요청 받음
   - [x] 응답 객체 만들기 - `FollowMemberResponse` : 멤버의 닉네임을 응답함
- [x] `FollowService` 작성하기
   - [x] 팔로우 실패시 예외 발생 - `AlreadyFollowException`을 발생 시킴 
   - [x] 예외 발생 시 핸들러 처리하기 - `MemberExceptionHandler`
   - [x] MemberErrorCode에 예외 메시지 추가
   - [x] `FollowServiceTest` 작성하기
- [x] `FollowRespository`와 `MemberRespository` 만들기
- [x] `Follow` 엔터티 수정
  - [x] 필드의 이름을 followerUid와 followingUid로 변경함 

