### PR TITLE
[FEAT] 멤버의 아이디나 닉네임으로 멤버 검색하는 기능 구현

### DIFF
--- a/src/main/java/com/jamjam/bookjeok/domains/member/controller/AdminController.java
+++ b/src/main/java/com/jamjam/bookjeok/domains/member/controller/AdminController.java
@@ -1,7 +1,9 @@
 package com.jamjam.bookjeok.domains.member.controller;
 
 import com.jamjam.bookjeok.common.dto.ApiResponse;
+import com.jamjam.bookjeok.domains.member.dto.request.MemberSearchRequest;
 import com.jamjam.bookjeok.domains.member.dto.request.PageRequest;
+import com.jamjam.bookjeok.domains.member.dto.response.MemberDetailResponse;
 import com.jamjam.bookjeok.domains.member.dto.response.MemberListResponse;
 import com.jamjam.bookjeok.domains.member.service.AdminService;
 import lombok.RequiredArgsConstructor;
@@ -25,6 +27,19 @@ public class AdminController {
             @Validated PageRequest pageRequest
     ){
         MemberListResponse response = adminService.getAllMembers(pageRequest);
+
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    @GetMapping("/admin/member")
+    public ResponseEntity<ApiResponse<MemberDetailResponse>> getMemberByName(
+            MemberSearchRequest memberSearchRequest
+    ){
+
+        MemberDetailResponse response = adminService.getMemberByIdOrNickname(memberSearchRequest);
+
+        log.info("멤버의 아이디 = " + response.getMember().getMemberId());
+        log.info("멤버의 닉네임 = " + response.getMember().getNickname());
 
         return ResponseEntity.ok(ApiResponse.success(response));
     }

--- a/src/main/java/com/jamjam/bookjeok/domains/member/dto/request/MemberSearchRequest.java
+++ b/src/main/java/com/jamjam/bookjeok/domains/member/dto/request/MemberSearchRequest.java
@@ -1,0 +1,13 @@
+package com.jamjam.bookjeok.domains.member.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class MemberSearchRequest {
+
+    private String memberId;
+    private String nickname;
+
+}

--- a/src/main/java/com/jamjam/bookjeok/domains/member/dto/response/MemberDetailResponse.java
+++ b/src/main/java/com/jamjam/bookjeok/domains/member/dto/response/MemberDetailResponse.java
@@ -4,7 +4,6 @@ import com.jamjam.bookjeok.domains.member.dto.MemberDTO;
 import lombok.*;
 
 @Getter
-@AllArgsConstructor
 @Builder
 public class MemberDetailResponse {
 

--- a/src/main/java/com/jamjam/bookjeok/domains/member/dto/response/MemberDetailResponse.java
+++ b/src/main/java/com/jamjam/bookjeok/domains/member/dto/response/MemberDetailResponse.java
@@ -1,0 +1,13 @@
+package com.jamjam.bookjeok.domains.member.dto.response;
+
+import com.jamjam.bookjeok.domains.member.dto.MemberDTO;
+import lombok.*;
+
+@Getter
+@AllArgsConstructor
+@Builder
+public class MemberDetailResponse {
+
+    private MemberDTO member;
+
+}

--- a/src/main/java/com/jamjam/bookjeok/domains/member/repository/mapper/AdminMapper.java
+++ b/src/main/java/com/jamjam/bookjeok/domains/member/repository/mapper/AdminMapper.java
@@ -1,5 +1,6 @@
 package com.jamjam.bookjeok.domains.member.repository.mapper;
 
+import com.jamjam.bookjeok.domains.member.dto.request.MemberSearchRequest;
 import com.jamjam.bookjeok.domains.member.dto.request.PageRequest;
 import com.jamjam.bookjeok.domains.member.dto.MemberDTO;
 import org.apache.ibatis.annotations.Mapper;
@@ -11,5 +12,7 @@ public interface AdminMapper {
     List<MemberDTO> findAllMember(PageRequest pageRequest);
 
     long countMembers();
+
+    MemberDTO findMemberByIdOrNickname(MemberSearchRequest memberSearchRequest);
 
 }

--- a/src/main/java/com/jamjam/bookjeok/domains/member/service/AdminService.java
+++ b/src/main/java/com/jamjam/bookjeok/domains/member/service/AdminService.java
@@ -1,14 +1,19 @@
 package com.jamjam.bookjeok.domains.member.service;
 
 import com.jamjam.bookjeok.common.dto.Pagination;
+import com.jamjam.bookjeok.domains.member.dto.request.MemberSearchRequest;
 import com.jamjam.bookjeok.domains.member.dto.request.PageRequest;
 import com.jamjam.bookjeok.domains.member.dto.MemberDTO;
+import com.jamjam.bookjeok.domains.member.dto.response.MemberDetailResponse;
 import com.jamjam.bookjeok.domains.member.dto.response.MemberListResponse;
 import com.jamjam.bookjeok.domains.member.repository.mapper.AdminMapper;
+import com.jamjam.bookjeok.exception.member.MemberErrorCode;
+import com.jamjam.bookjeok.exception.member.MemberException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import java.util.List;
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -34,6 +39,23 @@ public class AdminService {
                     .totalPage((int)Math.ceil((double)totalItems/size))
                     .totalItems(totalItems)
                     .build())
+                .build();
+    }
+
+    @Transactional(readOnly = true)
+    public MemberDetailResponse getMemberByIdOrNickname(MemberSearchRequest memberSearchRequest){
+        MemberDTO member = Optional.ofNullable(
+                adminMapper.findMemberByIdOrNickname(memberSearchRequest)
+        ).orElseThrow(() -> new MemberException(MemberErrorCode.NOT_EXIST_MEMBER));
+
+
+        if ((memberSearchRequest.getMemberId() == null || memberSearchRequest.getMemberId().isBlank()) &&
+                (memberSearchRequest.getNickname() == null || memberSearchRequest.getNickname().isBlank())) {
+            throw new MemberException(MemberErrorCode.MEMBER_SEARCH_CONDITION_MISSING);
+        }
+
+        return MemberDetailResponse.builder()
+                .member(member)
                 .build();
     }
 }

--- a/src/main/resources/mappers/member/AdminMapper.xml
+++ b/src/main/resources/mappers/member/AdminMapper.xml
@@ -29,4 +29,32 @@
         FROM members
         WHERE role = 'MEMBER'
     </select>
+
+    <select id="findMemberByIdOrNickname" resultType="MemberDTO">
+    SELECT
+        member_uid,
+        member_id,
+        member_name,
+        phone_number,
+        email,
+        nickname,
+        birth_date,
+        marketing_consent,
+        role,
+        created_at,
+        modified_at,
+        activity_status
+    FROM members
+    WHERE role = 'MEMBER'
+    <choose>
+        <when test="memberId != null and memberId != ''">
+            AND member_id = #{ memberId }
+        </when>
+        <when test="nickname != null and nickname != ''">
+            AND nickname = #{ nickname }
+        </when>
+    </choose>
+    ORDER BY member_uid;
+    </select>
+
 </mapper>

--- a/src/test/java/com/jamjam/bookjeok/domains/member/controller/AdminControllerTest.java
+++ b/src/test/java/com/jamjam/bookjeok/domains/member/controller/AdminControllerTest.java
@@ -7,6 +7,7 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.transaction.annotation.Transactional;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -32,6 +33,54 @@ class AdminControllerTest {
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.data.memberList").isArray())
                 .andExpect(jsonPath("$.timestamp").exists())
+                .andDo(print());
+    }
+
+    @Test
+    @DisplayName("멤버의 아이디로 멤버를 검색하는 테스트")
+    void getMemberByIdTest() throws Exception {
+        String memberId = "user02";
+
+        mockMvc.perform(MockMvcRequestBuilders.get("/api/v1/admin/member")
+                        .param("memberId", memberId))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.timestamp").exists())
+                .andExpect(jsonPath("$.data.member.memberId").value("user02"))
+                .andExpect(jsonPath("$.data.member.memberName").value("유형진"))
+                .andExpect(jsonPath("$.data.member.phoneNumber").value("01024001349"))
+                .andExpect(jsonPath("$.data.member.email").value("test2@gmail.com"))
+                .andExpect(jsonPath("$.data.member.nickname").value("닉네임02"))
+                .andExpect(jsonPath("$.data.member.birthDate").value("19970918"))
+                .andExpect(jsonPath("$.data.member.marketingConsent").value(true))
+                .andExpect(jsonPath("$.data.member.role").value("MEMBER"))
+                .andExpect(jsonPath("$.data.member.createdAt").value("2025-02-06T14:13:32"))
+                .andExpect(jsonPath("$.data.member.modifiedAt").isEmpty())
+                .andExpect(jsonPath("$.data.member.activityStatus").value("ACTIVE"))
+                .andDo(print());
+    }
+
+    @Test
+    @DisplayName("멤버의 닉네임으로 멤버를 검색하는 테스트")
+    void getMemberByNicknameTest() throws Exception {
+        String nickname = "닉네임02";
+
+        mockMvc.perform(MockMvcRequestBuilders.get("/api/v1/admin/member")
+                        .param("nickname", nickname))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.timestamp").exists())
+                .andExpect(jsonPath("$.data.member.memberId").value("user02"))
+                .andExpect(jsonPath("$.data.member.memberName").value("유형진"))
+                .andExpect(jsonPath("$.data.member.phoneNumber").value("01024001349"))
+                .andExpect(jsonPath("$.data.member.email").value("test2@gmail.com"))
+                .andExpect(jsonPath("$.data.member.nickname").value("닉네임02"))
+                .andExpect(jsonPath("$.data.member.birthDate").value("19970918"))
+                .andExpect(jsonPath("$.data.member.marketingConsent").value(true))
+                .andExpect(jsonPath("$.data.member.role").value("MEMBER"))
+                .andExpect(jsonPath("$.data.member.createdAt").value("2025-02-06T14:13:32"))
+                .andExpect(jsonPath("$.data.member.modifiedAt").isEmpty())
+                .andExpect(jsonPath("$.data.member.activityStatus").value("ACTIVE"))
                 .andDo(print());
     }
 }

--- a/src/test/java/com/jamjam/bookjeok/domains/member/repository/mapper/AdminMapperTest.java
+++ b/src/test/java/com/jamjam/bookjeok/domains/member/repository/mapper/AdminMapperTest.java
@@ -1,5 +1,6 @@
 package com.jamjam.bookjeok.domains.member.repository.mapper;
 
+import com.jamjam.bookjeok.domains.member.dto.request.MemberSearchRequest;
 import com.jamjam.bookjeok.domains.member.dto.request.PageRequest;
 import com.jamjam.bookjeok.domains.member.dto.MemberDTO;
 import org.junit.jupiter.api.DisplayName;
@@ -8,7 +9,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 import java.util.List;
-
 import static org.junit.jupiter.api.Assertions.*;
 
 @ActiveProfiles("test")
@@ -36,5 +36,30 @@ class AdminMapperTest {
     void countAllMember(){
         long count = adminMapper.countMembers();
         assertEquals(7, count);
+    }
+
+
+    @DisplayName("멤버의 아이디로 멤버를 검색하는 테스트")
+    @Test
+    void selectMemberByIdTest(){
+        String memberId = "user02";
+
+        MemberSearchRequest memberSearchRequest = new MemberSearchRequest(memberId,null);
+        MemberDTO member
+                = adminMapper.findMemberByIdOrNickname(memberSearchRequest);
+
+        assertEquals("유형진", member.getMemberName());
+    }
+
+    @DisplayName("멤버의 닉네임으로 멤버를 검색하는 테스트")
+    @Test
+    void selectMemberByNicknameTest(){
+        String nickname = "닉네임02";
+
+        MemberSearchRequest memberSearchRequest = new MemberSearchRequest(null,nickname);
+        MemberDTO member
+                = adminMapper.findMemberByIdOrNickname(memberSearchRequest);
+
+        assertEquals("유형진", member.getMemberName());
     }
 }

--- a/src/test/java/com/jamjam/bookjeok/domains/member/service/AdminServiceTest.java
+++ b/src/test/java/com/jamjam/bookjeok/domains/member/service/AdminServiceTest.java
@@ -1,10 +1,13 @@
 package com.jamjam.bookjeok.domains.member.service;
 
+import com.jamjam.bookjeok.domains.member.dto.request.MemberSearchRequest;
 import com.jamjam.bookjeok.domains.member.dto.request.PageRequest;
 import com.jamjam.bookjeok.domains.member.dto.MemberDTO;
+import com.jamjam.bookjeok.domains.member.dto.response.MemberDetailResponse;
 import com.jamjam.bookjeok.domains.member.dto.response.MemberListResponse;
 import com.jamjam.bookjeok.domains.member.entity.MemberRole;
 import com.jamjam.bookjeok.domains.member.repository.mapper.AdminMapper;
+import com.jamjam.bookjeok.exception.member.MemberException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -75,5 +78,84 @@ class AdminServiceTest {
 
         assertNotNull(response);
         assertEquals(2, response.getMemberList().size());
+    }
+
+    @DisplayName("getMemberById 서비스 단위 테스트")
+    @Test
+    void getMemberByIdTest() {
+        MemberSearchRequest searchRequest = new MemberSearchRequest("user02", null);
+        MemberDTO member = new MemberDTO(
+                1L,
+                "user01",
+                "정유진",
+                "01012345678",
+                "test1@gmail.com",
+                "닉네임01",
+                "19970816",
+                true,
+                MemberRole.MEMBER,
+                LocalDateTime.of(2025, 4, 6, 11, 13, 40),
+                LocalDateTime.of(2025, 4, 7, 11, 30, 40),
+                "ACTIVE"
+        );
+
+        when(adminMapper.findMemberByIdOrNickname(searchRequest)).thenReturn(member);
+
+        MemberDetailResponse result = adminService.getMemberByIdOrNickname(searchRequest);
+
+        assertNotNull(result);
+        assertEquals("정유진", result.getMember().getMemberName());
+    }
+
+    @DisplayName("getMemberByNickname 서비스 단위 테스트")
+    @Test
+    void getMemberByIdOrNicknameTest() {
+        MemberSearchRequest searchRequest = new MemberSearchRequest(null, "닉네임01");
+        MemberDTO member = new MemberDTO(
+                1L,
+                "user01",
+                "정유진",
+                "01012345678",
+                "test1@gmail.com",
+                "닉네임01",
+                "19970816",
+                true,
+                MemberRole.MEMBER,
+                LocalDateTime.of(2025, 4, 6, 11, 13, 40),
+                LocalDateTime.of(2025, 4, 7, 11, 30, 40),
+                "ACTIVE"
+        );
+
+        when(adminMapper.findMemberByIdOrNickname(searchRequest)).thenReturn(member);
+
+        MemberDetailResponse result = adminService.getMemberByIdOrNickname(searchRequest);
+
+        assertNotNull(result);
+        assertEquals("닉네임01", result.getMember().getNickname());
+    }
+
+    @DisplayName("아무것도 검색하지 않는 경우에 exception 발생")
+    @Test
+    void getMemberByIdOrNicknameExceptionTest() {
+        MemberSearchRequest searchRequest = new MemberSearchRequest(null, null);
+        MemberDTO member = new MemberDTO(
+                1L,
+                "user01",
+                "정유진",
+                "01012345678",
+                "test1@gmail.com",
+                "닉네임01",
+                "19970816",
+                true,
+                MemberRole.MEMBER,
+                LocalDateTime.of(2025, 4, 6, 11, 13, 40),
+                LocalDateTime.of(2025, 4, 7, 11, 30, 40),
+                "ACTIVE"
+        );
+
+        when(adminMapper.findMemberByIdOrNickname(searchRequest)).thenReturn(member);
+
+        assertThrows(MemberException.class,
+                () -> adminService.getMemberByIdOrNickname(searchRequest));
     }
 }


### PR DESCRIPTION
## ⭐ 구현 설명
멤버의 아이디나 닉네임으로 멤버를 검색하는 기능

## ✅ 구현한 내용
- `AdminMapper`
  - `AdminMapper.java` 작성 완료
  - `AdminMapper.xml` 작성 완료
    : 검색을 통해 멤버의 정보를 가져오는 쿼리문 작성 
  - `AdminMapperTest` 완료
- `AdminService`
  - 만약 없는 멤버라면 예외 발생
  - 이미 팔로우 하고 있는 경우라면 예외 발생
  - `AdminServiceTest` 완료
- `AdminController`
  - 검색 요청이 들어오면 검색을 해주는 컨트롤러
  - `AdminControllerTest` 완료
- `MemberDetailResponse` : MemberDTO를 반환하는 객체
- `MemberSearchRequest` : 멤버의 검색 조건 요청 객체


