### PR TITLE
[FEAT] 팔로우 삭제 기능 구현하기

### DIFF
--- a/src/main/java/com/jamjam/bookjeok/domains/member/controller/FollowController.java
+++ b/src/main/java/com/jamjam/bookjeok/domains/member/controller/FollowController.java
@@ -64,4 +64,19 @@ public class FollowController {
                 .status(HttpStatus.CREATED)
                 .body(ApiResponse.success(response));
     }
+
+    @DeleteMapping("/{followerId}/follow")
+    public ResponseEntity<ApiResponse<Void>> deleteFollow(
+            @RequestBody @Validated FollowMemberRequest followMemberRequest,
+            @PathVariable String followerId
+    ){
+        String followingId = followMemberRequest.getFollowingId();
+
+        log.info("followingId : {}", followingId);
+        log.info("followerId : {}", followerId);
+
+        followService.deleteFollow(followingId, followerId);
+
+        return ResponseEntity.ok(ApiResponse.success(null));
+    }
 }

--- a/src/main/java/com/jamjam/bookjeok/domains/member/repository/repository/FollowRepository.java
+++ b/src/main/java/com/jamjam/bookjeok/domains/member/repository/repository/FollowRepository.java
@@ -4,9 +4,13 @@ import com.jamjam.bookjeok.domains.member.entity.Follow;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface FollowRepository extends JpaRepository<Follow,Long> {
 
     boolean existsByFollowingUidAndFollowerUid(Long followingUid, Long followerUid);
+
+    Optional<Follow> findByFollowingUidAndFollowerUid(Long followingUid, Long followerUid);
 
 }

--- a/src/main/java/com/jamjam/bookjeok/exception/member/MemberErrorCode.java
+++ b/src/main/java/com/jamjam/bookjeok/exception/member/MemberErrorCode.java
@@ -8,7 +8,7 @@ import org.springframework.http.HttpStatus;
 @Getter
 @AllArgsConstructor(access = AccessLevel.PACKAGE)
 public enum MemberErrorCode {
-    NOT_FOLLOW("1000", "팔로우 하지 않는 사용자입니다.", HttpStatus.NOT_FOUND),
+    NOT_FOLLOW("1000", "팔로우 하지 않는 사용자입니다.", HttpStatus.BAD_REQUEST),
     NOT_EXIST_MEMBER("1001", "존재하지 않는 사용자입니다.", HttpStatus.NOT_FOUND),
     MEMBER_SEARCH_CONDITION_MISSING("1002", "memberId 또는 nickname 중 하나는 필수입니다", HttpStatus.BAD_REQUEST),
     NOT_FOUND_AUTHOR("1003", "존재하지 않는 작가입니다.", HttpStatus.NOT_FOUND),

--- a/src/main/java/com/jamjam/bookjeok/exception/member/MemberExceptionHandler.java
+++ b/src/main/java/com/jamjam/bookjeok/exception/member/MemberExceptionHandler.java
@@ -2,6 +2,7 @@ package com.jamjam.bookjeok.exception.member;
 
 import com.jamjam.bookjeok.common.dto.ApiResponse;
 import com.jamjam.bookjeok.exception.member.followException.AlreadyFollowException;
+import com.jamjam.bookjeok.exception.member.followException.NotFollowException;
 import com.jamjam.bookjeok.exception.member.interestAuthorException.AlreadyInterestedAuthorException;
 import com.jamjam.bookjeok.exception.member.interestAuthorException.AuthorNotFoundException;
 import org.springframework.http.ResponseEntity;
@@ -14,6 +15,7 @@ public class MemberExceptionHandler {
     @ExceptionHandler(MemberException.class)
     public ResponseEntity<ApiResponse> handleMemberException(MemberException e){
         MemberErrorCode errorCode = e.getMemberErrorCode();
+
         ApiResponse<Void> response
                 = ApiResponse.failure(errorCode.getCode(), errorCode.getMessage());
 
@@ -23,6 +25,7 @@ public class MemberExceptionHandler {
     @ExceptionHandler(AuthorNotFoundException.class)
     public ResponseEntity<ApiResponse> handleAuthorNotFoundException(AuthorNotFoundException e){
         MemberErrorCode errorCode = e.getMemberErrorCode();
+
         ApiResponse<Void> response
                 = ApiResponse.failure(errorCode.getCode(), errorCode.getMessage());
 
@@ -32,6 +35,7 @@ public class MemberExceptionHandler {
     @ExceptionHandler(AlreadyInterestedAuthorException.class)
     public ResponseEntity<ApiResponse> handleAlreadyInterestedAuthorException(AlreadyInterestedAuthorException e){
         MemberErrorCode errorCode = e.getMemberErrorCode();
+
         ApiResponse<Void> response
                 = ApiResponse.failure(errorCode.getCode(), errorCode.getMessage());
 
@@ -41,6 +45,17 @@ public class MemberExceptionHandler {
     @ExceptionHandler(AlreadyFollowException.class)
     public ResponseEntity<ApiResponse> handleAlreadyFollowException(AlreadyFollowException e){
         MemberErrorCode errorCode = e.getMemberErrorCode();
+
+        ApiResponse<Void> response
+                = ApiResponse.failure(errorCode.getCode(), errorCode.getMessage());
+
+        return new ResponseEntity<>(response,errorCode.getHttpStatus());
+    }
+
+    @ExceptionHandler(NotFollowException.class)
+    public ResponseEntity<ApiResponse> handleNotFollowException(NotFollowException e){
+        MemberErrorCode errorCode = e.getMemberErrorCode();
+
         ApiResponse<Void> response
                 = ApiResponse.failure(errorCode.getCode(), errorCode.getMessage());
 

--- a/src/main/java/com/jamjam/bookjeok/exception/member/followException/NotFollowException.java
+++ b/src/main/java/com/jamjam/bookjeok/exception/member/followException/NotFollowException.java
@@ -1,0 +1,15 @@
+package com.jamjam.bookjeok.exception.member.followException;
+
+import com.jamjam.bookjeok.exception.member.MemberErrorCode;
+import lombok.Getter;
+
+@Getter
+public class NotFollowException extends RuntimeException{
+
+    private final MemberErrorCode memberErrorCode;
+
+    public NotFollowException(MemberErrorCode memberErrorCode) {
+        super(memberErrorCode.getMessage());
+        this.memberErrorCode = memberErrorCode;
+    }
+}

--- a/src/test/java/com/jamjam/bookjeok/domains/member/controller/FollowControllerTest.java
+++ b/src/test/java/com/jamjam/bookjeok/domains/member/controller/FollowControllerTest.java
@@ -12,6 +12,8 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.transaction.annotation.Transactional;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -63,7 +65,7 @@ class FollowControllerTest {
 
     }
 
-    @DisplayName("팔로우 하기")
+    @DisplayName("팔로우 하기 테스트")
     @Test
     void createFollowTest() throws Exception {
         String followerId = "user01";
@@ -80,4 +82,17 @@ class FollowControllerTest {
                 .andReturn();
     }
 
+    @DisplayName("팔로우 취소하기 테스트")
+    @Test
+    void deleteFollowTest() throws Exception {
+        String followerId = "user01";
+        String followingId = "user02";
+
+        FollowMemberRequest followMemberRequest = new FollowMemberRequest(followingId);
+
+        mockMvc.perform(delete("/api/v1/{followerId}/follow", followerId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(followMemberRequest)))
+                .andExpect(jsonPath("$.success").value(true));
+    }
 }

--- a/src/test/java/com/jamjam/bookjeok/domains/member/service/FollowServiceTest.java
+++ b/src/test/java/com/jamjam/bookjeok/domains/member/service/FollowServiceTest.java
@@ -2,7 +2,9 @@ package com.jamjam.bookjeok.domains.member.service;
 
 import com.jamjam.bookjeok.domains.member.dto.FollowDTO;
 import com.jamjam.bookjeok.domains.member.dto.PostSummaryDTO;
+import com.jamjam.bookjeok.domains.member.repository.repository.FollowRepository;
 import com.jamjam.bookjeok.exception.member.followException.AlreadyFollowException;
+import com.jamjam.bookjeok.exception.member.followException.NotFollowException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -21,6 +23,8 @@ class FollowServiceTest {
 
     @Autowired
     private FollowService followService;
+    @Autowired
+    private FollowRepository followRepository;
 
     @DisplayName("멤버의 id 통해 팔로우 목록 가져오기")
     @Test
@@ -68,6 +72,19 @@ class FollowServiceTest {
         assertThrows(AlreadyFollowException.class, () -> {
             followService.createFollow(followingId, followerId);
         });
+    }
+
+    @DisplayName("팔로우 취소 테스트")
+    @Test
+    void deleteFollowTest(){
+        String followingId = "user02";
+        String followerId = "user01";
+
+        followService.deleteFollow(followingId, followerId);
+
+        // 팔로우가 취소 됐으므로
+        assertThrows(NotFollowException.class, () ->
+            followService.deleteFollow(followingId, followerId));
     }
 
 }


### PR DESCRIPTION
## ⭐ 기능 구현
팔로우 삭제 기능 구현하기

## ✅ 내용 구현하기
- `MemberExceptionHandler`
   - `NotFollowException` 만들기
   - `NotFollowException` 핸들링 처리하기
- `FollowController`
  - followMemberRequest 요청을 받음
  - 삭제 성공 시 성공 여부 반환하기
- `FollowService` 
  - `FollowServiceTest` 수행하기
  - 만약 팔로우 관계가 없는 경우라면 예외 처리 발생하기