### PR TITLE
[FEAT] 관심 도서 추가 기능 구현

### DIFF
--- a/src/main/java/com/jamjam/bookjeok/domains/member/controller/InterestBookController.java
+++ b/src/main/java/com/jamjam/bookjeok/domains/member/controller/InterestBookController.java
@@ -1,10 +1,16 @@
 package com.jamjam.bookjeok.domains.member.controller;
 
 import com.jamjam.bookjeok.common.dto.ApiResponse;
+import com.jamjam.bookjeok.domains.member.dto.request.InterestAuthorRequest;
+import com.jamjam.bookjeok.domains.member.dto.request.InterestBookRequest;
 import com.jamjam.bookjeok.domains.member.dto.request.PageRequest;
+import com.jamjam.bookjeok.domains.member.dto.response.InterestAuthorResponse;
 import com.jamjam.bookjeok.domains.member.dto.response.InterestBookListResponse;
+import com.jamjam.bookjeok.domains.member.dto.response.InterestBookResponse;
+import com.jamjam.bookjeok.domains.member.entity.InterestBook;
 import com.jamjam.bookjeok.domains.member.service.InterestBookService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
@@ -25,6 +31,24 @@ public class InterestBookController {
                 interestBookService.getInterestBookListByMemberId(memberId, pageRequest);
 
         return ResponseEntity.ok(ApiResponse.success(interestBookList));
+    }
+
+    @PostMapping("/interest-book")
+    public ResponseEntity<ApiResponse<InterestBookResponse>> createInterestAuthor(
+            @RequestBody @Validated InterestBookRequest request
+    ){
+
+        Long memberUid = 1L;
+
+        String bookName = interestBookService.createInterestBook(memberUid, request);
+
+        InterestBookResponse response = InterestBookResponse.builder()
+                .bookName(bookName)
+                .build();
+
+        return ResponseEntity
+                .status(HttpStatus.CREATED)
+                .body(ApiResponse.success(response));
     }
 
 }

--- a/src/main/java/com/jamjam/bookjeok/domains/member/dto/request/InterestBookRequest.java
+++ b/src/main/java/com/jamjam/bookjeok/domains/member/dto/request/InterestBookRequest.java
@@ -8,10 +8,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class InterestBookRequest {
 
-    @NotNull(message = "책의 이름은 비어있을 수 없습니다.")
-    private final String bookName;
-
-    @NotNull(message = "멤버 아이디는 비어있을 수 없습니다.")
-    private final Long memberUid;
+    @NotNull(message = "책의 아이디는 비어있을 수 없습니다.")
+    private final Long bookId;
 
 }

--- a/src/main/java/com/jamjam/bookjeok/domains/member/dto/response/InterestBookResponse.java
+++ b/src/main/java/com/jamjam/bookjeok/domains/member/dto/response/InterestBookResponse.java
@@ -1,0 +1,12 @@
+package com.jamjam.bookjeok.domains.member.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class InterestBookResponse {
+
+    private String bookName;
+
+}

--- a/src/main/java/com/jamjam/bookjeok/domains/member/entity/InterestBook.java
+++ b/src/main/java/com/jamjam/bookjeok/domains/member/entity/InterestBook.java
@@ -2,6 +2,7 @@ package com.jamjam.bookjeok.domains.member.entity;
 
 import jakarta.persistence.*;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -13,5 +14,10 @@ public class InterestBook {
 
     @Id @EmbeddedId
     private InterestBookId interestBookId;
+
+    @Builder
+    public InterestBook(InterestBookId interestBookId){
+        this.interestBookId = interestBookId;
+    }
 
 }

--- a/src/main/java/com/jamjam/bookjeok/domains/member/repository/mapper/InterestBookMapper.java
+++ b/src/main/java/com/jamjam/bookjeok/domains/member/repository/mapper/InterestBookMapper.java
@@ -14,4 +14,7 @@ public interface InterestBookMapper {
             @Param("memberId") String memberId,
             @Param("pageRequest") PageRequest pageRequest
     );
+
+    int countInterestBookByMemberUid(Long memberUid);
+
 }

--- a/src/main/java/com/jamjam/bookjeok/domains/member/repository/repository/InterestBookRepository.java
+++ b/src/main/java/com/jamjam/bookjeok/domains/member/repository/repository/InterestBookRepository.java
@@ -1,0 +1,13 @@
+package com.jamjam.bookjeok.domains.member.repository.repository;
+
+import com.jamjam.bookjeok.domains.member.entity.InterestBook;
+import com.jamjam.bookjeok.domains.member.entity.InterestBookId;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface InterestBookRepository extends JpaRepository<InterestBook, InterestBookId> {
+
+    boolean existsById(InterestBookId interestBookId);
+
+}

--- a/src/main/java/com/jamjam/bookjeok/domains/member/service/InterestBookService.java
+++ b/src/main/java/com/jamjam/bookjeok/domains/member/service/InterestBookService.java
@@ -1,11 +1,23 @@
 package com.jamjam.bookjeok.domains.member.service;
 
 import com.jamjam.bookjeok.common.dto.Pagination;
+import com.jamjam.bookjeok.domains.book.entity.Book;
+import com.jamjam.bookjeok.domains.book.repository.BookRepository;
+import com.jamjam.bookjeok.domains.member.dto.request.InterestBookRequest;
 import com.jamjam.bookjeok.domains.member.dto.request.PageRequest;
 import com.jamjam.bookjeok.domains.member.dto.InterestBookDTO;
 import com.jamjam.bookjeok.domains.member.dto.response.InterestBookListResponse;
+import com.jamjam.bookjeok.domains.member.dto.response.InterestBookResponse;
+import com.jamjam.bookjeok.domains.member.entity.InterestBook;
+import com.jamjam.bookjeok.domains.member.entity.InterestBookId;
 import com.jamjam.bookjeok.domains.member.repository.mapper.InterestBookMapper;
+import com.jamjam.bookjeok.domains.member.repository.repository.InterestBookRepository;
+import com.jamjam.bookjeok.exception.member.MemberErrorCode;
+import com.jamjam.bookjeok.exception.member.interestBookException.AlreadyInterestedBookException;
+import com.jamjam.bookjeok.exception.member.interestBookException.InterestBookLimitExceededException;
+import com.jamjam.bookjeok.exception.member.interestBookException.NotFoundBookException;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -13,9 +25,12 @@ import java.util.List;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class InterestBookService {
 
     private final InterestBookMapper interestBookMapper;
+    private final BookRepository bookRepository;
+    private final InterestBookRepository interestBookRepository;
 
     @Transactional(readOnly = true)
     public InterestBookListResponse getInterestBookListByMemberId(
@@ -37,5 +52,42 @@ public class InterestBookService {
                         .totalItems(totalBooks)
                         .build())
                 .build();
+    }
+
+    @Transactional
+    public String createInterestBook(
+            Long memberUid, // 로그인 부분 완성 되면 제거 -> 로그인 된 사용자를 가져오면 됨
+            InterestBookRequest interestBookRequest
+    ){
+
+        int totalInterestedBook = interestBookMapper.countInterestBookByMemberUid(memberUid);
+
+        log.info("관심도서의 수는 : {}", totalInterestedBook);
+
+        // 관심도서는 최대 30권까지
+        if(totalInterestedBook == 30){
+            throw new InterestBookLimitExceededException(MemberErrorCode.INTEREST_BOOK_LIMIT_EXCEEDED);
+        }
+
+        // 만약 없는 도서라면 예외 발생시키기
+        Book book = bookRepository.findBookByBookId(interestBookRequest.getBookId())
+                .orElseThrow(() -> new NotFoundBookException(MemberErrorCode.NOT_FOUND_BOOK));
+
+        InterestBookId interestBookId
+                = new InterestBookId(interestBookRequest.getBookId(), memberUid);
+
+        if(interestBookRepository.existsById(interestBookId)){
+            throw new AlreadyInterestedBookException(MemberErrorCode.ALREADY_INTERESTED_BOOK);
+        }
+
+        InterestBook interestBook = InterestBook.builder()
+                .interestBookId(interestBookId)
+                .build();
+
+        interestBookRepository.save(interestBook);
+
+        log.info("책이 저장 됨");
+
+        return book.getBookName();
     }
 }

--- a/src/main/java/com/jamjam/bookjeok/exception/member/MemberErrorCode.java
+++ b/src/main/java/com/jamjam/bookjeok/exception/member/MemberErrorCode.java
@@ -8,14 +8,17 @@ import org.springframework.http.HttpStatus;
 @Getter
 @AllArgsConstructor(access = AccessLevel.PACKAGE)
 public enum MemberErrorCode {
-    NOT_FOLLOW("1000", "팔로우 하지 않는 사용자입니다.", HttpStatus.BAD_REQUEST),
+    NOT_FOLLOW("1000", "팔로우 하지 않는 사용자입니다.", HttpStatus.FORBIDDEN),
     NOT_EXIST_MEMBER("1001", "존재하지 않는 사용자입니다.", HttpStatus.NOT_FOUND),
     MEMBER_SEARCH_CONDITION_MISSING("1002", "memberId 또는 nickname 중 하나는 필수입니다", HttpStatus.BAD_REQUEST),
     NOT_FOUND_AUTHOR("1003", "존재하지 않는 작가입니다.", HttpStatus.NOT_FOUND),
-    ALREADY_INTERESTED_AUTHOR("1004", "이미 즐겨찾기에 추가한 작가입니다.", HttpStatus.ALREADY_REPORTED),
-    INTEREST_AUTHOR_LIMIT_EXCEEDED("1005","관심 작가는 최대 30명까지 등록할 수 있습니다.", HttpStatus.TOO_MANY_REQUESTS),
-    NOT_REGIST_AUTHOR("1006", "관심 작가에 등록되어 있지 않습니다.", HttpStatus.NOT_FOUND),
-    ALREADY_FOLLOW("1007", "이미 팔로우 하고 있는 사용자 입니다.", HttpStatus.ALREADY_REPORTED);
+    ALREADY_INTERESTED_AUTHOR("1004", "이미 관심 작가에 추가됐습니다.", HttpStatus.CONFLICT),
+    INTEREST_AUTHOR_LIMIT_EXCEEDED("1005", "관심 작가는 최대 30명까지 등록할 수 있습니다.", HttpStatus.BAD_REQUEST),
+    NOT_REGIST_AUTHOR("1006", "관심 작가에 등록되어 있지 않습니다.", HttpStatus.BAD_REQUEST),
+    ALREADY_FOLLOW("1007", "이미 팔로우 하고 있는 사용자 입니다.", HttpStatus.CONFLICT),
+    NOT_FOUND_BOOK("1008", "존재하지 않는 도서입니다.", HttpStatus.NOT_FOUND),
+    INTEREST_BOOK_LIMIT_EXCEEDED("1009", "관심 도서는 최대 30권까지 등록할 수 있습니다.", HttpStatus.BAD_REQUEST),
+    ALREADY_INTERESTED_BOOK("1010", "이미 관심 도서에 추가 됐습니다.", HttpStatus.CONFLICT);
 
     private final String code;
     private final String message;

--- a/src/main/java/com/jamjam/bookjeok/exception/member/MemberExceptionHandler.java
+++ b/src/main/java/com/jamjam/bookjeok/exception/member/MemberExceptionHandler.java
@@ -5,6 +5,10 @@ import com.jamjam.bookjeok.exception.member.followException.AlreadyFollowExcepti
 import com.jamjam.bookjeok.exception.member.followException.NotFollowException;
 import com.jamjam.bookjeok.exception.member.interestAuthorException.AlreadyInterestedAuthorException;
 import com.jamjam.bookjeok.exception.member.interestAuthorException.AuthorNotFoundException;
+import com.jamjam.bookjeok.exception.member.interestAuthorException.InterestAuthorLimitExceededException;
+import com.jamjam.bookjeok.exception.member.interestBookException.AlreadyInterestedBookException;
+import com.jamjam.bookjeok.exception.member.interestBookException.InterestBookLimitExceededException;
+import com.jamjam.bookjeok.exception.member.interestBookException.NotFoundBookException;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -24,6 +28,16 @@ public class MemberExceptionHandler {
 
     @ExceptionHandler(AuthorNotFoundException.class)
     public ResponseEntity<ApiResponse> handleAuthorNotFoundException(AuthorNotFoundException e){
+        MemberErrorCode errorCode = e.getMemberErrorCode();
+
+        ApiResponse<Void> response
+                = ApiResponse.failure(errorCode.getCode(), errorCode.getMessage());
+
+        return new ResponseEntity<>(response,errorCode.getHttpStatus());
+    }
+
+    @ExceptionHandler(InterestAuthorLimitExceededException.class)
+    public ResponseEntity<ApiResponse> handleInterestAuthorLimitExceededException(InterestAuthorLimitExceededException e){
         MemberErrorCode errorCode = e.getMemberErrorCode();
 
         ApiResponse<Void> response
@@ -54,6 +68,34 @@ public class MemberExceptionHandler {
 
     @ExceptionHandler(NotFollowException.class)
     public ResponseEntity<ApiResponse> handleNotFollowException(NotFollowException e){
+        MemberErrorCode errorCode = e.getMemberErrorCode();
+
+        ApiResponse<Void> response
+                = ApiResponse.failure(errorCode.getCode(), errorCode.getMessage());
+
+        return new ResponseEntity<>(response,errorCode.getHttpStatus());
+    }
+
+    @ExceptionHandler(AlreadyInterestedBookException.class)
+    public ResponseEntity<ApiResponse> handleAlreadyInterestedBookException(AlreadyInterestedBookException e){
+        MemberErrorCode errorCode = e.getMemberErrorCode();
+
+        ApiResponse<Void> response
+                = ApiResponse.failure(errorCode.getCode(), errorCode.getMessage());
+
+        return new ResponseEntity<>(response,errorCode.getHttpStatus());
+    }
+    @ExceptionHandler(InterestBookLimitExceededException.class)
+    public ResponseEntity<ApiResponse> handleInterestBookLimitExceededException(InterestBookLimitExceededException e){
+        MemberErrorCode errorCode = e.getMemberErrorCode();
+
+        ApiResponse<Void> response
+                = ApiResponse.failure(errorCode.getCode(), errorCode.getMessage());
+
+        return new ResponseEntity<>(response,errorCode.getHttpStatus());
+    }
+    @ExceptionHandler(NotFoundBookException.class)
+    public ResponseEntity<ApiResponse> handleNotFoundBookException(NotFoundBookException e){
         MemberErrorCode errorCode = e.getMemberErrorCode();
 
         ApiResponse<Void> response

--- a/src/main/java/com/jamjam/bookjeok/exception/member/interestBookException/AlreadyInterestedBookException.java
+++ b/src/main/java/com/jamjam/bookjeok/exception/member/interestBookException/AlreadyInterestedBookException.java
@@ -1,0 +1,15 @@
+package com.jamjam.bookjeok.exception.member.interestBookException;
+
+import com.jamjam.bookjeok.exception.member.MemberErrorCode;
+import lombok.Getter;
+
+@Getter
+public class AlreadyInterestedBookException extends RuntimeException{
+
+    private final MemberErrorCode memberErrorCode;
+
+    public AlreadyInterestedBookException(MemberErrorCode memberErrorCode) {
+        super(memberErrorCode.getMessage());
+        this.memberErrorCode = memberErrorCode;
+    }
+}

--- a/src/main/java/com/jamjam/bookjeok/exception/member/interestBookException/InterestBookLimitExceededException.java
+++ b/src/main/java/com/jamjam/bookjeok/exception/member/interestBookException/InterestBookLimitExceededException.java
@@ -1,0 +1,15 @@
+package com.jamjam.bookjeok.exception.member.interestBookException;
+
+import com.jamjam.bookjeok.exception.member.MemberErrorCode;
+import lombok.Getter;
+
+@Getter
+public class InterestBookLimitExceededException extends RuntimeException {
+
+    private final MemberErrorCode memberErrorCode;
+
+    public InterestBookLimitExceededException(MemberErrorCode memberErrorCode) {
+        super(memberErrorCode.getMessage());
+        this.memberErrorCode = memberErrorCode;
+    }
+}

--- a/src/main/java/com/jamjam/bookjeok/exception/member/interestBookException/NotFoundBookException.java
+++ b/src/main/java/com/jamjam/bookjeok/exception/member/interestBookException/NotFoundBookException.java
@@ -1,0 +1,15 @@
+package com.jamjam.bookjeok.exception.member.interestBookException;
+
+import com.jamjam.bookjeok.exception.member.MemberErrorCode;
+import lombok.Getter;
+
+@Getter
+public class NotFoundBookException extends RuntimeException{
+
+    private final MemberErrorCode memberErrorCode;
+
+    public NotFoundBookException(MemberErrorCode memberErrorCode) {
+        super(memberErrorCode.getMessage());
+        this.memberErrorCode = memberErrorCode;
+    }
+}

--- a/src/main/resources/mappers/member/InterestBookMapper.xml
+++ b/src/main/resources/mappers/member/InterestBookMapper.xml
@@ -17,4 +17,10 @@
         WHERE m.member_id = #{ memberId }
         LIMIT #{ pageRequest.limit } OFFSET #{ pageRequest.offset };
     </select>
+
+    <select id="countInterestBookByMemberUid" resultType="_int">
+        SELECT COUNT(*)
+        FROM interest_books
+        WHERE member_uid = #{ memberUid }
+    </select>
 </mapper>

--- a/src/test/java/com/jamjam/bookjeok/domains/member/controller/InterestBookControllerTest.java
+++ b/src/test/java/com/jamjam/bookjeok/domains/member/controller/InterestBookControllerTest.java
@@ -1,23 +1,29 @@
 package com.jamjam.bookjeok.domains.member.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.jamjam.bookjeok.domains.member.dto.request.InterestAuthorRequest;
+import com.jamjam.bookjeok.domains.member.dto.request.InterestBookRequest;
+import com.jamjam.bookjeok.domains.member.dto.response.InterestBookResponse;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.transaction.annotation.Transactional;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @SpringBootTest
-@AutoConfigureMockMvc
-@ActiveProfiles("test")
 @Transactional
+@ActiveProfiles("test")
+@AutoConfigureMockMvc
 class InterestBookControllerTest {
 
     @Autowired
@@ -46,4 +52,17 @@ class InterestBookControllerTest {
                 .andDo(print());
     }
 
+    @DisplayName("관심 도서 등록하기")
+    @Test
+    void createInterestBookTest() throws Exception {
+        InterestBookRequest request = new InterestBookRequest(5L);
+
+        mockMvc.perform(post("/api/v1/interest-book")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.bookName").value("노르웨이의 숲"))
+                .andReturn();
+    }
 }

--- a/src/test/java/com/jamjam/bookjeok/domains/member/repository/mapper/InterestBookMapperTest.java
+++ b/src/test/java/com/jamjam/bookjeok/domains/member/repository/mapper/InterestBookMapperTest.java
@@ -30,4 +30,14 @@ class InterestBookMapperTest {
         assertNotNull(bookList);
     }
 
+    @DisplayName("특정 회원의 관심 도서의 수 가져오기")
+    @Test
+    void countInterestBookByMemberUidTest(){
+        Long memberUid = 2L;
+
+        int count = interestBookMapper.countInterestBookByMemberUid(memberUid);
+
+        assertEquals(2, count);
+    }
+
 }


### PR DESCRIPTION
## ⭐기능 설명
회원의 관심 도서 추가 기능 구현

## ✅설명
- `InterestBookRequest`로 책의 Id 넘겨받기
- `InterestBookResponse`로 관심 도서를 추가했을 경우 도서의 이름 받기
- `InterestBookController`
  -  관심 도서추가 Controller 테스트 
-  `InterestBookService`
   - 관심 도서 등록 시 30권을 초과하지 않는 것을 확인하기 위한 도서 개수 세는 Mapper 작성 
   - 관심 도서 등록 시 30권 초과하지 않게 등록 시 확인해서 예외 처리
   - 이미 관심 도서에 등록된 도서인 경우 추가하지 않기
   - 추가하려는 도서가 존재하지 않는 경우 예외 처리
   - 관심 도서 관련 예외 핸들링 및 에러 코드 작성
   - 관심 도서 추가 Service 테스트
- `InterestBookRepository`


