### PR TITLE
[FEAT] 관심 도서 삭제 기능 구현

### DIFF
--- a/src/main/java/com/jamjam/bookjeok/domains/member/controller/InterestBookController.java
+++ b/src/main/java/com/jamjam/bookjeok/domains/member/controller/InterestBookController.java
@@ -1,13 +1,10 @@
 package com.jamjam.bookjeok.domains.member.controller;
 
 import com.jamjam.bookjeok.common.dto.ApiResponse;
-import com.jamjam.bookjeok.domains.member.dto.request.InterestAuthorRequest;
 import com.jamjam.bookjeok.domains.member.dto.request.InterestBookRequest;
 import com.jamjam.bookjeok.domains.member.dto.request.PageRequest;
-import com.jamjam.bookjeok.domains.member.dto.response.InterestAuthorResponse;
 import com.jamjam.bookjeok.domains.member.dto.response.InterestBookListResponse;
 import com.jamjam.bookjeok.domains.member.dto.response.InterestBookResponse;
-import com.jamjam.bookjeok.domains.member.entity.InterestBook;
 import com.jamjam.bookjeok.domains.member.service.InterestBookService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -34,10 +31,9 @@ public class InterestBookController {
     }
 
     @PostMapping("/interest-book")
-    public ResponseEntity<ApiResponse<InterestBookResponse>> createInterestAuthor(
+    public ResponseEntity<ApiResponse<InterestBookResponse>> createInterestBook(
             @RequestBody @Validated InterestBookRequest request
     ){
-
         Long memberUid = 1L;
 
         String bookName = interestBookService.createInterestBook(memberUid, request);
@@ -49,6 +45,18 @@ public class InterestBookController {
         return ResponseEntity
                 .status(HttpStatus.CREATED)
                 .body(ApiResponse.success(response));
+    }
+
+    @DeleteMapping("/interest-book")
+    public ResponseEntity<ApiResponse<Void>> deleteInterestBook(
+            @RequestBody @Validated InterestBookRequest request
+    ){
+        // 로그인 연결 후 수정
+        Long memberUid = 1L;
+
+        interestBookService.deleteInterestBook(memberUid, request);
+
+        return ResponseEntity.ok(ApiResponse.success(null));
     }
 
 }

--- a/src/main/java/com/jamjam/bookjeok/domains/member/service/InterestBookService.java
+++ b/src/main/java/com/jamjam/bookjeok/domains/member/service/InterestBookService.java
@@ -7,12 +7,14 @@ import com.jamjam.bookjeok.domains.member.dto.request.InterestBookRequest;
 import com.jamjam.bookjeok.domains.member.dto.request.PageRequest;
 import com.jamjam.bookjeok.domains.member.dto.InterestBookDTO;
 import com.jamjam.bookjeok.domains.member.dto.response.InterestBookListResponse;
-import com.jamjam.bookjeok.domains.member.dto.response.InterestBookResponse;
+import com.jamjam.bookjeok.domains.member.entity.InterestAuthor;
+import com.jamjam.bookjeok.domains.member.entity.InterestAuthorId;
 import com.jamjam.bookjeok.domains.member.entity.InterestBook;
 import com.jamjam.bookjeok.domains.member.entity.InterestBookId;
 import com.jamjam.bookjeok.domains.member.repository.mapper.InterestBookMapper;
 import com.jamjam.bookjeok.domains.member.repository.repository.InterestBookRepository;
 import com.jamjam.bookjeok.exception.member.MemberErrorCode;
+import com.jamjam.bookjeok.exception.member.interestAuthorException.AuthorNotFoundException;
 import com.jamjam.bookjeok.exception.member.interestBookException.AlreadyInterestedBookException;
 import com.jamjam.bookjeok.exception.member.interestBookException.InterestBookLimitExceededException;
 import com.jamjam.bookjeok.exception.member.interestBookException.NotFoundBookException;
@@ -90,4 +92,22 @@ public class InterestBookService {
 
         return book.getBookName();
     }
+
+    @Transactional
+    public void deleteInterestBook(
+            Long memberUid, // 로그인 부분 완성 되면 제거 -> 로그인 된 사용자를 가져오면 됨
+            InterestBookRequest interestBookRequest
+    ){
+        Book book = bookRepository.findBookByBookId(interestBookRequest.getBookId())
+                .orElseThrow(() -> new NotFoundBookException(MemberErrorCode.NOT_FOUND_BOOK));
+
+        InterestBookId interestBookId
+                = new InterestBookId(interestBookRequest.getBookId(), memberUid);
+
+        InterestBook interestBook = interestBookRepository.findById(interestBookId)
+                .orElseThrow(() -> new NotFoundBookException(MemberErrorCode.NOT_REGIST_INTEREST_BOOK));
+
+        interestBookRepository.delete(interestBook);
+    }
+
 }

--- a/src/main/java/com/jamjam/bookjeok/exception/member/MemberErrorCode.java
+++ b/src/main/java/com/jamjam/bookjeok/exception/member/MemberErrorCode.java
@@ -18,7 +18,8 @@ public enum MemberErrorCode {
     ALREADY_FOLLOW("1007", "이미 팔로우 하고 있는 사용자 입니다.", HttpStatus.CONFLICT),
     NOT_FOUND_BOOK("1008", "존재하지 않는 도서입니다.", HttpStatus.NOT_FOUND),
     INTEREST_BOOK_LIMIT_EXCEEDED("1009", "관심 도서는 최대 30권까지 등록할 수 있습니다.", HttpStatus.BAD_REQUEST),
-    ALREADY_INTERESTED_BOOK("1010", "이미 관심 도서에 추가 됐습니다.", HttpStatus.CONFLICT);
+    ALREADY_INTERESTED_BOOK("1010", "이미 관심 도서에 추가 됐습니다.", HttpStatus.CONFLICT),
+    NOT_REGIST_INTEREST_BOOK("1011", "관심 도서에 등록되어 있지 않습니다.", HttpStatus.BAD_REQUEST);
 
     private final String code;
     private final String message;

--- a/src/test/java/com/jamjam/bookjeok/domains/member/controller/InterestBookControllerTest.java
+++ b/src/test/java/com/jamjam/bookjeok/domains/member/controller/InterestBookControllerTest.java
@@ -1,9 +1,7 @@
 package com.jamjam.bookjeok.domains.member.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.jamjam.bookjeok.domains.member.dto.request.InterestAuthorRequest;
 import com.jamjam.bookjeok.domains.member.dto.request.InterestBookRequest;
-import com.jamjam.bookjeok.domains.member.dto.response.InterestBookResponse;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -15,6 +13,7 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.transaction.annotation.Transactional;
 
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -64,5 +63,16 @@ class InterestBookControllerTest {
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.data.bookName").value("노르웨이의 숲"))
                 .andReturn();
+    }
+
+    @DisplayName("관심 도서 삭제하기")
+    @Test
+    void deleteInterestBookTest() throws Exception {
+        InterestBookRequest request = new InterestBookRequest(2L);
+
+        mockMvc.perform(delete("/api/v1/interest-book")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(jsonPath("$.success").value(true));
     }
 }

--- a/src/test/java/com/jamjam/bookjeok/domains/member/service/InterestBookServiceTest.java
+++ b/src/test/java/com/jamjam/bookjeok/domains/member/service/InterestBookServiceTest.java
@@ -69,7 +69,17 @@ class InterestBookServiceTest {
                 () ->  interestBookService.createInterestBook(memberUid, request));
     }
 
+    @DisplayName("관심 도서 삭제 후 존재 여부 확인해 예외 발생")
+    @Test
+    void deleteInterestAuthorTest(){
+        Long memberUid = 2L;
 
+        InterestBookRequest request = new InterestBookRequest(2L);
 
+        interestBookService.deleteInterestBook(memberUid, request);
 
+        assertThrows(NotFoundBookException.class, () -> {
+            interestBookService.deleteInterestBook(memberUid, request);
+        });
+    }
 }


### PR DESCRIPTION
## ⭐기능 설명
회원의 관심 도서 삭제 기능 구현

## ✅설명
- `InterestBookRequest`로 책의 Id 넘겨받기
- `InterestBookController`
  -  관심 도서 삭제 Controller 테스트 
-  `InterestBookService`
   - 관심 도서에 등록되어 있지 않는 도서를 삭제하려고 하는 경우 예외 처리
   - 관심 도서 관련 삭제 예외 핸들링 및 에러 코드 작성
   - 관심 도서 삭제 Service 테스트
- `InterestBookRepository`


