### PR TITLE
[FEATURE] 회원 문의사항 조회, 등록, 수정, 삭제 기능 개발

### DIFF
--- a/src/main/java/com/jamjam/bookjeok/domains/question/controller/QuestionMemberController.java
+++ b/src/main/java/com/jamjam/bookjeok/domains/question/controller/QuestionMemberController.java
@@ -1,0 +1,115 @@
+package com.jamjam.bookjeok.domains.question.controller;
+
+import com.jamjam.bookjeok.common.dto.ApiResponse;
+import com.jamjam.bookjeok.domains.question.dto.QuestionCategoryDTO;
+import com.jamjam.bookjeok.domains.question.dto.QuestionDTO;
+import com.jamjam.bookjeok.domains.question.dto.QuestionListDTO;
+import com.jamjam.bookjeok.domains.question.dto.request.QuestionRequest;
+import com.jamjam.bookjeok.domains.question.dto.response.QuestionResponse;
+import com.jamjam.bookjeok.domains.question.service.QuestionMemberService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/{memberUid}")
+public class QuestionMemberController {
+
+    private final QuestionMemberService questionMemberService;
+
+    @GetMapping("/question")
+    public ResponseEntity<ApiResponse<List<QuestionListDTO>>> findMemberQuestions(@PathVariable Long memberUid) {
+
+        Map<String, Object> params  = new HashMap<>();
+        params.put("memberUid", memberUid);
+        List<QuestionListDTO> questions = questionMemberService.findMemberQuestions(params);
+
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(ApiResponse.success(questions));
+    }
+
+    @GetMapping("/question/{questionId}")
+    public ResponseEntity<ApiResponse<QuestionDTO>> findMemberQuestionDetail(@PathVariable Long memberUid, @PathVariable Long questionId) {
+
+        Map<String, Object> params  = new HashMap<>();
+        params.put("memberUid", memberUid);
+        params.put("questionId", questionId);
+        QuestionDTO question = questionMemberService.findMemberQuestion(params);
+
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(ApiResponse.success(question));
+
+    }
+
+    @GetMapping("/question/in")
+    public ResponseEntity<ApiResponse<List<QuestionCategoryDTO>>> getQuestionInsertPage() {
+
+        List<QuestionCategoryDTO> categories = getQuestionCategories();
+
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(ApiResponse.success(categories));
+
+    }
+
+    @PostMapping("/question/in")
+    public ResponseEntity<ApiResponse<QuestionResponse>> registQuestion(
+            @RequestPart @Validated QuestionRequest request,
+            @RequestPart MultipartFile questionImg) {
+
+        QuestionResponse response = questionMemberService.registQuestion(request, questionImg);
+
+        return ResponseEntity
+                .status(HttpStatus.CREATED)
+                .body(ApiResponse.success(response));
+    }
+
+    @PutMapping("/question/mod/{questionId}")
+    public ResponseEntity<ApiResponse<QuestionResponse>> modifyQuestion(
+            @PathVariable Long questionId,
+            @RequestPart @Validated QuestionRequest request,
+            @RequestPart MultipartFile questionImg) {
+
+        validReceivedAnswer(questionId);
+
+        QuestionResponse response = questionMemberService.modifyQuestion(questionId, request, questionImg);
+
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(ApiResponse.success(response));
+    }
+
+    @DeleteMapping("/question/del/{questionId}")
+    public ResponseEntity<ApiResponse<QuestionResponse>> deleteQuestion(
+            @PathVariable Long questionId) {
+
+        QuestionResponse response = questionMemberService.deleteQuestion(questionId);
+
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(ApiResponse.success(response));
+
+    }
+
+    private  List<QuestionCategoryDTO> getQuestionCategories() {
+
+        return questionMemberService.getQuestionCategories();
+    }
+
+    private void validReceivedAnswer(Long questionId) {
+
+        questionMemberService.validReceivedAnswer(questionId);
+
+    }
+
+}

--- a/src/main/java/com/jamjam/bookjeok/domains/question/dto/QuestionCategoryDTO.java
+++ b/src/main/java/com/jamjam/bookjeok/domains/question/dto/QuestionCategoryDTO.java
@@ -1,0 +1,17 @@
+package com.jamjam.bookjeok.domains.question.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@Getter
+@ToString
+@NoArgsConstructor
+@AllArgsConstructor
+public class QuestionCategoryDTO {
+
+    private Long questionCategoryId;
+    private String questionCategoryName;
+
+}

--- a/src/main/java/com/jamjam/bookjeok/domains/question/dto/request/QuestionRequest.java
+++ b/src/main/java/com/jamjam/bookjeok/domains/question/dto/request/QuestionRequest.java
@@ -1,0 +1,13 @@
+package com.jamjam.bookjeok.domains.question.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
+
+@Builder
+public record QuestionRequest(
+        @NotNull(message = "작성자는 반드시 입력해야 합니다.") Long writerUid,
+        @NotNull(message = "문의 항목은 반드시 선택해야 합니다.") Long questionCategoryId,
+        @NotBlank(message = "제목은 반드시 입력해야 합니다.") String title,
+        @NotBlank(message = "문의 내용은 반드시 입력해야 합니다.") String contents) {
+}

--- a/src/main/java/com/jamjam/bookjeok/domains/question/dto/response/QuestionResponse.java
+++ b/src/main/java/com/jamjam/bookjeok/domains/question/dto/response/QuestionResponse.java
@@ -1,0 +1,11 @@
+package com.jamjam.bookjeok.domains.question.dto.response;
+
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+
+@Builder
+public record QuestionResponse(
+        Long questionId, Long writerUid, Long questionCategoryId,
+        String title, String contents, LocalDateTime createdAt,
+        LocalDateTime modifiedAt, boolean isDeleted) {}

--- a/src/main/java/com/jamjam/bookjeok/domains/question/entity/Question.java
+++ b/src/main/java/com/jamjam/bookjeok/domains/question/entity/Question.java
@@ -59,4 +59,20 @@ public class Question {
         this.questionsImgUrl = questionsImgUrl;
     }
 
+    public void updateQuestion(final String title, final String contents,
+                               final LocalDateTime modifiedAt) {
+        this.title = title;
+        this.contents = contents;
+        this.modifiedAt = modifiedAt;
+    }
+
+    public void changeImageUrl(String questionsImgUrl) {
+        this.questionsImgUrl = questionsImgUrl;
+    }
+
+    public void deleteQuestion(final LocalDateTime modifiedAt, final boolean isDeleted) {
+        this.modifiedAt = modifiedAt;
+        this.isDeleted = isDeleted;
+    }
+
 }

--- a/src/main/java/com/jamjam/bookjeok/domains/question/repository/QuestionAnswerRepository.java
+++ b/src/main/java/com/jamjam/bookjeok/domains/question/repository/QuestionAnswerRepository.java
@@ -3,8 +3,11 @@ package com.jamjam.bookjeok.domains.question.repository;
 import com.jamjam.bookjeok.domains.question.entity.QuestionAnswer;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface QuestionAnswerRepository extends JpaRepository<QuestionAnswer, Long> {
     Optional<QuestionAnswer> findByAnswerId(Long answerId);
+
+    Optional<List<QuestionAnswer>> findByQuestionId(Long questionId);
 }

--- a/src/main/java/com/jamjam/bookjeok/domains/question/repository/QuestionRepository.java
+++ b/src/main/java/com/jamjam/bookjeok/domains/question/repository/QuestionRepository.java
@@ -1,0 +1,10 @@
+package com.jamjam.bookjeok.domains.question.repository;
+
+import com.jamjam.bookjeok.domains.question.entity.Question;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface QuestionRepository extends JpaRepository<Question, Long> {
+    Optional<Question> findByQuestionId(Long questionId);
+}

--- a/src/main/java/com/jamjam/bookjeok/domains/question/repository/mapper/QuestionMapper.java
+++ b/src/main/java/com/jamjam/bookjeok/domains/question/repository/mapper/QuestionMapper.java
@@ -1,5 +1,6 @@
 package com.jamjam.bookjeok.domains.question.repository.mapper;
 
+import com.jamjam.bookjeok.domains.question.dto.QuestionCategoryDTO;
 import com.jamjam.bookjeok.domains.question.dto.QuestionDTO;
 import com.jamjam.bookjeok.domains.question.dto.QuestionListDTO;
 import org.apache.ibatis.annotations.Mapper;
@@ -12,4 +13,8 @@ public interface QuestionMapper{
     List<QuestionListDTO> findQuestions(Map<String, Object> params);
 
     QuestionDTO findQuestionByQuestionId(Map<String, Object> params);
+
+    List<QuestionListDTO> findMemberQuestions(Map<String, Object> params);
+
+    List<QuestionCategoryDTO> findQuestionCategories();
 }

--- a/src/main/java/com/jamjam/bookjeok/domains/question/service/QuestionMemberService.java
+++ b/src/main/java/com/jamjam/bookjeok/domains/question/service/QuestionMemberService.java
@@ -1,0 +1,27 @@
+package com.jamjam.bookjeok.domains.question.service;
+
+import com.jamjam.bookjeok.domains.question.dto.QuestionCategoryDTO;
+import com.jamjam.bookjeok.domains.question.dto.QuestionDTO;
+import com.jamjam.bookjeok.domains.question.dto.QuestionListDTO;
+import com.jamjam.bookjeok.domains.question.dto.request.QuestionRequest;
+import com.jamjam.bookjeok.domains.question.dto.response.QuestionResponse;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+import java.util.Map;
+
+public interface QuestionMemberService {
+    List<QuestionListDTO> findMemberQuestions( Map<String, Object> params);
+
+    QuestionDTO findMemberQuestion(Map<String, Object> params);
+
+    List<QuestionCategoryDTO> getQuestionCategories();
+
+    QuestionResponse registQuestion(QuestionRequest request, MultipartFile questionImg);
+
+    void validReceivedAnswer(Long questionId);
+
+    QuestionResponse modifyQuestion(Long questionId, QuestionRequest request, MultipartFile questionImg);
+
+    QuestionResponse deleteQuestion(Long questionId);
+}

--- a/src/main/java/com/jamjam/bookjeok/domains/question/service/QuestionMemberServiceImpl.java
+++ b/src/main/java/com/jamjam/bookjeok/domains/question/service/QuestionMemberServiceImpl.java
@@ -1,0 +1,147 @@
+package com.jamjam.bookjeok.domains.question.service;
+
+import com.jamjam.bookjeok.common.service.FileStorageService;
+import com.jamjam.bookjeok.domains.question.dto.QuestionCategoryDTO;
+import com.jamjam.bookjeok.domains.question.dto.QuestionDTO;
+import com.jamjam.bookjeok.domains.question.dto.QuestionListDTO;
+import com.jamjam.bookjeok.domains.question.dto.request.QuestionRequest;
+import com.jamjam.bookjeok.domains.question.dto.response.QuestionResponse;
+import com.jamjam.bookjeok.domains.question.entity.Question;
+import com.jamjam.bookjeok.domains.question.entity.QuestionAnswer;
+import com.jamjam.bookjeok.domains.question.repository.QuestionAnswerRepository;
+import com.jamjam.bookjeok.domains.question.repository.QuestionRepository;
+import com.jamjam.bookjeok.domains.question.repository.mapper.QuestionMapper;
+import com.jamjam.bookjeok.exception.question.InconsistentQuestionException;
+import com.jamjam.bookjeok.exception.question.NotFoundQuestionException;
+import com.jamjam.bookjeok.exception.question.QuestionErrorCode;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class QuestionMemberServiceImpl implements QuestionMemberService{
+
+    private final QuestionMapper questionMapper;
+    private final QuestionAnswerRepository questionAnswerRepository;
+    private final QuestionRepository questionRepository;
+    private final FileStorageService fileStorageService;
+
+    @Value("${image.image-url}")
+    private String IMAGE_URL;
+
+    @Override
+    public List<QuestionListDTO> findMemberQuestions( Map<String, Object> params) {
+        return questionMapper.findMemberQuestions(params);
+    }
+
+    @Override
+    public QuestionDTO findMemberQuestion(Map<String, Object> params) {
+        return questionMapper.findQuestionByQuestionId(params);
+    }
+
+    @Override
+    public List<QuestionCategoryDTO> getQuestionCategories() {
+        return questionMapper.findQuestionCategories();
+    }
+
+    @Override
+    public QuestionResponse registQuestion(QuestionRequest request, MultipartFile questionImg) {
+
+        String replaceFileName = fileStorageService.storeFile(questionImg);
+
+        Question question = Question.builder()
+                .questionCategoriesId(request.questionCategoryId())
+                .writerUid(request.writerUid())
+                .title(request.title())
+                .contents(request.contents())
+                .questionsImgUrl(replaceFileName)
+                .build();
+
+        Question newQuestion = questionRepository.save(question);
+
+        return buildQuestionResponse(newQuestion);
+    }
+
+    @Override
+    public void validReceivedAnswer(Long questionId) {
+
+        Optional<List<QuestionAnswer>> findAnswers = questionAnswerRepository.findByQuestionId(questionId);
+
+        if(!findAnswers.get().isEmpty()) {
+            throw new InconsistentQuestionException(QuestionErrorCode.RECEIVED_ANSWER_QUESTION);
+        }
+
+    }
+
+    @Override
+    public QuestionResponse modifyQuestion(Long questionId, QuestionRequest request, MultipartFile questionImg) {
+
+        Optional<Question> findQuestion = questionRepository.findByQuestionId(questionId);
+
+        if(findQuestion.isEmpty()) {
+            throw new NotFoundQuestionException(QuestionErrorCode.NOTFOUND_QUESTION);
+        }
+
+        if(questionImg != null) {
+            String replaceFileName = fileStorageService.storeFile(questionImg);
+            if(findQuestion.get().getQuestionsImgUrl() != null){
+                String oldFileName = findQuestion.get().getQuestionsImgUrl().replace(IMAGE_URL,"");
+                fileStorageService.deleteFile(oldFileName);
+            }
+            findQuestion.get().changeImageUrl(replaceFileName);
+        }
+
+        findQuestion.get().updateQuestion(
+                request.title(),
+                request.contents(),
+                LocalDateTime.now()
+        );
+
+        Question modQuestion = questionRepository.save(findQuestion.get());
+
+        return buildQuestionResponse(modQuestion);
+
+    }
+
+    @Override
+    public QuestionResponse deleteQuestion(Long questionId) {
+        Optional<Question> findQuestion = questionRepository.findByQuestionId(questionId);
+
+        if(findQuestion.isEmpty()) {
+            throw new NotFoundQuestionException(QuestionErrorCode.NOTFOUND_QUESTION);
+        }
+
+        findQuestion.get().deleteQuestion(
+                LocalDateTime.now(),
+                true
+        );
+
+        Question delQuestion = questionRepository.save(findQuestion.get());
+
+        return buildQuestionResponse(delQuestion);
+    }
+
+
+    private QuestionResponse buildQuestionResponse(Question question) {
+
+        return QuestionResponse.builder()
+                .questionId(question.getQuestionId())
+                .questionCategoryId(question.getQuestionCategoriesId())
+                .writerUid(question.getWriterUid())
+                .title(question.getTitle())
+                .contents(question.getContents())
+                .createdAt(question.getCreatedAt())
+                .modifiedAt(question.getModifiedAt())
+                .isDeleted(question.isDeleted())
+                .build();
+    }
+}

--- a/src/main/java/com/jamjam/bookjeok/exception/question/QuestionErrorCode.java
+++ b/src/main/java/com/jamjam/bookjeok/exception/question/QuestionErrorCode.java
@@ -10,7 +10,9 @@ import org.springframework.http.HttpStatus;
 public enum QuestionErrorCode {
 
     INCONSISTENT_ANSWER("1000", "답변이 일치하지 않습니다.", HttpStatus.BAD_REQUEST),
-    NOTFOUND_ANSWER("1001", "존재하지 않는 답변입니다.", HttpStatus.BAD_REQUEST);
+    NOTFOUND_ANSWER("1001", "존재하지 않는 답변입니다.", HttpStatus.BAD_REQUEST),
+    RECEIVED_ANSWER_QUESTION("1002", "이미 답변을 받은 문의사항입니다.", HttpStatus.BAD_REQUEST),
+    NOTFOUND_QUESTION("1003", "존재하지 않는 문의사항 입니다.", HttpStatus.BAD_REQUEST);
 
     private final String code;
     private final String message;

--- a/src/main/resources/mappers/question/QuestionMapper.xml
+++ b/src/main/resources/mappers/question/QuestionMapper.xml
@@ -48,7 +48,34 @@
          JOIN question_category b ON (a.question_categories_id = b.question_category_id)
          JOIN members c ON (a.writer_uid = member_uid)
         WHERE a.is_deleted = false
+          <if test="memberUid != null">
+              AND a.writer_uid = #{ memberUid }
+          </if>
           AND a.question_id = #{ questionId };
     </select>
 
+    <select id="findMemberQuestions" resultType="QuestionListDTO">
+        SELECT
+            a.question_id
+            , a.writer_uid
+            , c.member_name
+            , b.question_category_id
+            , b.question_category_name
+            , a.title
+            , a.created_at
+            , a.modified_at
+        FROM questions a
+        JOIN question_category b ON (a.question_categories_id = b.question_category_id)
+        JOIN members c ON (a.writer_uid = member_uid)
+        WHERE a.is_deleted = false
+        AND a.writer_uid = #{ memberUid }
+        ORDER BY a.created_at DESC, modified_at DESC;
+    </select>
+
+    <select id="findQuestionCategories" resultType="QuestionCategoryDTO">
+        SELECT
+              question_category_id
+            , question_category_name
+        FROM question_category
+    </select>
 </mapper>

--- a/src/test/java/com/jamjam/bookjeok/domains/question/controller/QuestionMemberControllerTest.java
+++ b/src/test/java/com/jamjam/bookjeok/domains/question/controller/QuestionMemberControllerTest.java
@@ -1,0 +1,221 @@
+package com.jamjam.bookjeok.domains.question.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.transaction.Transactional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@ActiveProfiles("test")
+@SpringBootTest
+@AutoConfigureMockMvc
+@Transactional
+public class QuestionMemberControllerTest {
+
+    @Autowired
+    private MockMvc mvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    private static final String BASE_URL = "/api/v1";
+
+    @DisplayName("회원 문의사항 조회 테스트")
+    @Test
+    void testFindMemberQuestions() throws Exception {
+
+        Long memberUid = 1L;
+
+        mvc.perform(get(BASE_URL + "/{memberUid}/question", memberUid)
+                    .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andDo(print())
+                .andExpect(content().string(containsString("questionId")));
+    }
+
+    @DisplayName("회원 문의사항 상세 조회 테스트")
+    @Test
+    void testFindMemberQuestionDetail() throws Exception {
+
+        Long memberUid = 1L;
+        Long questionId = 1L;
+
+        mvc.perform(get(BASE_URL + "/{memberUid}/question/{questionId}", memberUid, questionId)
+                    .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andDo(print())
+                .andExpect(content().string(containsString("contents")));
+
+    }
+
+    @DisplayName("회원 문의사항 등록 페이지 호출 시 문의사항 카테고리 조회 테스트")
+    @Test
+    void testGetQuestionInsertPage() throws Exception {
+        Long memberUid = 1L;
+
+        mvc.perform(get(BASE_URL + "/{memberUid}/question/in", memberUid)
+                    .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andDo(print())
+                .andExpect(content().string(containsString(("questionCategoryId"))));
+
+    }
+
+    @DisplayName("회원 문의사항 등록 테스트")
+    @Test
+    void testRegistQuestion() throws Exception {
+        Long memberUid = 1L;
+
+        MockMultipartFile imageFile = new MockMultipartFile(
+                "questionImg", "cover.png", "image/png", "fake image data".getBytes());
+
+        MockMultipartFile jsonFile = new MockMultipartFile(
+                "request", "request", "application/json",
+                """
+                {
+                  "writerUid": 1,
+                  "questionCategoryId": 1,
+                  "title": "등록성공",
+                  "contents": "등록 잘 되었는지 확인해주실 수 있나요?"
+                }
+                """.getBytes()
+        );
+
+        mvc.perform(multipart(BASE_URL + "/{memberUid}/question/in", memberUid)
+                    .file(imageFile)
+                    .file(jsonFile)
+                    .contentType(MediaType.MULTIPART_FORM_DATA))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.data.questionId").exists())
+                .andExpect(jsonPath("$.data.writerUid").value(1L))
+                .andExpect(jsonPath("$.data.questionCategoryId").value(1L))
+                .andExpect(jsonPath("$.data.title").value("등록성공"))
+                .andExpect(jsonPath("$.data.contents").value("등록 잘 되었는지 확인해주실 수 있나요?"));
+
+    }
+
+    @DisplayName("회원 문의사항 등록 필수값 누락 예외 발생 테스트")
+    @Test
+    void testRegistQuestionException() throws Exception {
+        Long memberUid = 1L;
+
+        MockMultipartFile imageFile = new MockMultipartFile(
+                "questionImg", "cover.png", "image/png", "fake image data".getBytes());
+
+        MockMultipartFile jsonFile = new MockMultipartFile(
+                "request", "request", "application/json",
+                """
+                {
+                  "writerUid": 1,
+                  "questionCategoryId": null,
+                  "title": "등록성공",
+                  "contents": "등록 잘 되었는지 확인해주실 수 있나요?"
+                }
+                """.getBytes()
+        );
+
+        mvc.perform(multipart(HttpMethod.POST, BASE_URL + "/{memberUid}/question/in", memberUid)
+                        .file(imageFile)
+                        .file(jsonFile)
+                        .contentType(MediaType.MULTIPART_FORM_DATA))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.message").value("문의 항목은 반드시 선택해야 합니다."))
+                .andExpect(header().string(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE));
+
+    }
+
+    @DisplayName("문의사항 수정 테스트")
+    @Test
+    void testModifyQuestion() throws Exception {
+        Long memberUid = 7L;
+        Long questionUid = 7L;
+
+        MockMultipartFile imageFile = new MockMultipartFile(
+                "questionImg", "cover.png", "image/png", "fake image data".getBytes());
+
+        MockMultipartFile jsonFile = new MockMultipartFile(
+                "request", "request", "application/json",
+                """
+                {
+                  "writerUid": 7,
+                  "questionCategoryId": 2,
+                  "title": "수정 성공",
+                  "contents": "수정 잘 되었는지 확인해주실 수 있나요?"
+                }
+                """.getBytes()
+        );
+
+        mvc.perform(multipart(HttpMethod.PUT,BASE_URL + "/{memberUid}/question/mod/{questionId}", memberUid, questionUid)
+                        .file(imageFile)
+                        .file(jsonFile)
+                        .contentType(MediaType.MULTIPART_FORM_DATA))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.questionId").exists())
+                .andExpect(jsonPath("$.data.modifiedAt").exists())
+                .andExpect(jsonPath("$.data.writerUid").value(7L))
+                .andExpect(jsonPath("$.data.questionCategoryId").value(2L))
+                .andExpect(jsonPath("$.data.title").value("수정 성공"))
+                .andExpect(jsonPath("$.data.contents").value("수정 잘 되었는지 확인해주실 수 있나요?"));
+    }
+
+    @DisplayName("이미 답변 받은 문의 사항 수정 시 예외 발생 테스트")
+    @Test
+    void testModifyQuestionValidReceiveAnswer() throws Exception {
+
+        Long memberUid = 1L;
+        Long questionUid = 1L;
+
+        MockMultipartFile imageFile = new MockMultipartFile(
+                "questionImg", "cover.png", "image/png", "fake image data".getBytes());
+
+        MockMultipartFile jsonFile = new MockMultipartFile(
+                "request", "request", "application/json",
+                """
+                {
+                  "writerUid": 1,
+                  "questionCategoryId": 1,
+                  "title": "예외 발생",
+                  "contents": "예외가 발생했나요?"
+                }
+                """.getBytes()
+        );
+
+        mvc.perform(multipart(HttpMethod.PUT,BASE_URL + "/{memberUid}/question/mod/{questionId}", memberUid, questionUid)
+                        .file(imageFile)
+                        .file(jsonFile)
+                        .contentType(MediaType.MULTIPART_FORM_DATA))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.message").value("이미 답변을 받은 문의사항입니다."))
+                .andExpect(header().string(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE));
+    }
+
+    @DisplayName("문의사항 삭제 테스트")
+    @Test
+    void testDeleteQuestion() throws Exception {
+
+        Long memberUid = 1L;
+        Long questionId = 1L;
+
+        mvc.perform(delete(BASE_URL + "/{memberUid}/question/del/{questionId}", memberUid, questionId)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andDo(print())
+                .andExpect(jsonPath("$.data.isDeleted").value(true));
+    }
+
+}

--- a/src/test/java/com/jamjam/bookjeok/domains/question/mapper/QuestionMapperTest.java
+++ b/src/test/java/com/jamjam/bookjeok/domains/question/mapper/QuestionMapperTest.java
@@ -1,5 +1,6 @@
 package com.jamjam.bookjeok.domains.question.mapper;
 
+import com.jamjam.bookjeok.domains.question.dto.QuestionCategoryDTO;
 import com.jamjam.bookjeok.domains.question.dto.QuestionDTO;
 import com.jamjam.bookjeok.domains.question.dto.QuestionListDTO;
 import com.jamjam.bookjeok.domains.question.repository.mapper.QuestionMapper;
@@ -41,7 +42,7 @@ public class QuestionMapperTest {
 
     @DisplayName("문의사항 상세 조회 테스트")
     @Test
-    void findQuestionByQuestionId() {
+    void testFindQuestionByQuestionId() {
 
         Map<String, Object> params = new HashMap<>();
         Long questionId = 2L;
@@ -51,6 +52,46 @@ public class QuestionMapperTest {
 
         assertThat(question).isNotNull();
         log.info("{}", question);
+    }
+
+    @DisplayName("회원 문의사항 목록 조회 테스트")
+    @Test
+    void testFindMemberQuestions() {
+
+        Long memberUid = 1L;
+        Map<String, Object> params = new HashMap<>();
+        params.put("memberUid", memberUid);
+
+        List<QuestionListDTO> questions = questionMapper.findMemberQuestions(params);
+
+        assertThat(questions).isNotNull();
+        questions.forEach(System.out::println);
+    }
+
+    @DisplayName("회원 문의사항 상세 조회 테스트")
+    @Test
+    void testMemberFindQuestionByQuestionId() {
+        Long memberUid = 1L;
+        Long questionId = 1L;
+        Map<String, Object> params = new HashMap<>();
+        params.put("memberUid", memberUid);
+        params.put("questionId", questionId);
+
+        QuestionDTO question = questionMapper.findQuestionByQuestionId(params);
+
+        assertThat(question).isNotNull();
+        log.info("{}", question);
+    }
+
+    @DisplayName("문의사항 카테고리 조회 테스트")
+    @Test
+    void testFindQuestionCategories() {
+
+        List<QuestionCategoryDTO> categories = questionMapper.findQuestionCategories();
+
+        assertThat(categories).isNotNull();
+        categories.forEach(System.out::println);
+
     }
 }
 

--- a/src/test/java/com/jamjam/bookjeok/domains/question/service/QuestionMemberServiceTest.java
+++ b/src/test/java/com/jamjam/bookjeok/domains/question/service/QuestionMemberServiceTest.java
@@ -1,0 +1,178 @@
+package com.jamjam.bookjeok.domains.question.service;
+
+import com.jamjam.bookjeok.domains.question.dto.QuestionCategoryDTO;
+import com.jamjam.bookjeok.domains.question.dto.QuestionDTO;
+import com.jamjam.bookjeok.domains.question.dto.QuestionListDTO;
+import com.jamjam.bookjeok.domains.question.dto.request.QuestionRequest;
+import com.jamjam.bookjeok.domains.question.dto.response.QuestionResponse;
+import com.jamjam.bookjeok.exception.question.NotFoundQuestionException;
+import jakarta.transaction.Transactional;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+
+@Slf4j
+@Transactional
+@SpringBootTest
+@ActiveProfiles("test")
+public class QuestionMemberServiceTest {
+
+    @Autowired
+    QuestionMemberService questionMemberService;
+
+    @DisplayName("회원 문의사항 조회 테스트")
+    @Test
+    void testFindMemberQuestions() {
+
+        Long memberUid = 1L;
+        Map<String, Object> params = new HashMap<>();
+        params.put("memberUid", memberUid);
+
+        List<QuestionListDTO> questions = questionMemberService.findMemberQuestions(params);
+
+        assertThat(questions).isNotNull();
+
+        questions.forEach(System.out::println);
+
+    }
+
+    @DisplayName("회원 문의사항 상세 조회 테스트")
+    @Test
+    void findQuestionByQuestionId() throws Exception {
+
+        Long memberUid = 1L;
+        Long questionId = 1L;
+
+        Map<String, Object> params = new HashMap<>();
+        params.put("memberUid", memberUid);
+        params.put("questionId", questionId);
+
+        QuestionDTO question = questionMemberService.findMemberQuestion(params);
+
+        assertThat(question).isNotNull();
+        log.info("{}", question);
+
+    }
+
+    @DisplayName("문의사항 카테고리 조회 테스트")
+    @Test
+    void testGetQuestionCategories() {
+
+        List<QuestionCategoryDTO> categories = questionMemberService.getQuestionCategories();
+
+        assertThat(categories).isNotNull();
+
+        categories.forEach(System.out::println);
+
+    }
+
+    @DisplayName("회원 문의사항 등록 테스트")
+    @Test
+    void testRegistQuestion() {
+
+        Long memberUid = 1L;
+        Long categoryId = 1L;
+        String title = "등록 성공";
+        String contents = "등록 잘 되었는지 확인해주실 수 있나요?";
+
+        MockMultipartFile imageFile = new MockMultipartFile(
+                "questionImg", "cover.png", "image/png", "fake image data".getBytes());
+
+        QuestionRequest request = QuestionRequest.builder()
+                .writerUid(memberUid)
+                .questionCategoryId(categoryId)
+                .title(title)
+                .contents(contents)
+                .build();
+
+        QuestionResponse response = questionMemberService.registQuestion(request, imageFile);
+
+        assertThat(response).isNotNull();
+        assertThat(response.questionId()).isNotNull();
+        assertThat(response.title()).isEqualTo(title);
+        assertThat(response.contents()).isEqualTo(contents);
+
+    }
+
+    @DisplayName("회원 문의사항 수정 테스트")
+    @Test
+    void testModifyQuestion() throws Exception {
+        Long memberUid = 7L;
+        Long questionId = 7L;
+        Long categoryId = 1L;
+        String title = "수정 성공";
+        String contents = "수정 잘 되었는지 확인해주실 수 있나요?";
+
+        MockMultipartFile imageFile = new MockMultipartFile(
+                "questionImg", "cover.png", "image/png", "fake image data".getBytes());
+
+        QuestionRequest request = QuestionRequest.builder()
+                .writerUid(memberUid)
+                .questionCategoryId(categoryId)
+                .title(title)
+                .contents(contents)
+                .build();
+
+        QuestionResponse response = questionMemberService.modifyQuestion(questionId, request, imageFile);
+
+        assertThat(response).isNotNull();
+        assertThat(response.questionId()).isEqualTo(questionId);
+        assertThat(response.questionCategoryId()).isEqualTo(categoryId);
+        assertThat(response.title()).isEqualTo(title);
+        assertThat(response.contents()).isEqualTo(contents);
+        assertThat(response.modifiedAt()).isNotNull();
+
+    }
+
+    @DisplayName("회원 문의 사항 수정 시 예외 발생 테스트")
+    @Test
+    void testModifyQuestionException() {
+        Long memberUid = 7L;
+        Long questionId = 123456L;
+        Long categoryId = 1L;
+        String title = "수정 성공";
+        String contents = "수정 잘 되었는지 확인해주실 수 있나요?";
+
+        MockMultipartFile imageFile = new MockMultipartFile(
+                "questionImg", "cover.png", "image/png", "fake image data".getBytes());
+
+        QuestionRequest request = QuestionRequest.builder()
+                .writerUid(memberUid)
+                .questionCategoryId(categoryId)
+                .title(title)
+                .contents(contents)
+                .build();
+
+        assertThatThrownBy(() -> questionMemberService.modifyQuestion(questionId, request, imageFile))
+                .isInstanceOf(NotFoundQuestionException.class)
+                .hasMessage("존재하지 않는 문의사항 입니다.");
+
+    }
+
+    @DisplayName("회원 문의사항 삭제 테스트")
+    @Test
+    void testDeleteQuestion() {
+
+        Long questionId = 1L;
+
+        QuestionResponse response = questionMemberService.deleteQuestion(questionId);
+
+        assertThat(response).isNotNull();
+        assertThat(response.modifiedAt()).isNotNull();
+        assertThat(response.isDeleted()).isEqualTo(true);
+
+    }
+
+
+}


### PR DESCRIPTION
**회원 문의사항 조회, 등록, 수정, 삭제 기능 개발** (#25)

✅ 문의사항 목록 조회 및 상세 조회
- 최신 등록된 순으로 조회
- 문의사항ID, 회원UID 값으로 상세 조회
 
✅ 문의사항 비즈니스 로직 처리
- 카테고리 선택 후 문의사항 등록
- 작성한 문의사항  수정
- 작성한 문의사항 삭제

✅ 문의사항 등록/수정/삭제 예외 상황 컨트롤
- InconsistentQuestionException
   - RECEIVED_ANSWER_QUESTION: 이미 답변 받은 문의사항 수정 불가 처리
 - NotFoundQuestionException
   - NOTFOUND_QUESTION : 존재하지 않는 문의사항 조회

✅ 회원 문의사항 조회 비즈니스 로직 처리 테스트
- QuestionMemberController
  - 컨트롤러 호출을 통한 문의사항 비즈니스 로직 처리 
- QuestionMemberServiceImpl
  - 문의 사항 비즈니스 로직 처리
  - 예외 상황 컨트롤  
- QeustionMapper
  - 회원이 등록한 문의 사항 조회
  - 문의 사항 등록, 수정, 삭제 