### PR TITLE
[FIX] 도서 재고 수량이 부족한 경우 임시 주문 정보 삭제가 안되는 부분 수정

### DIFF
--- a/src/main/java/com/jamjam/bookjeok/domains/order/controller/order/PendingOrderController.java
+++ b/src/main/java/com/jamjam/bookjeok/domains/order/controller/order/PendingOrderController.java
@@ -8,10 +8,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api/v1")
@@ -20,7 +17,7 @@ public class PendingOrderController {
 
     private final PendingOrderService pendingOrderService;
 
-    @PostMapping("/order/payment")
+    @PostMapping("/pending-order")
     public ResponseEntity<ApiResponse<PendingOrderResponse>> createOrder(
             @RequestBody @Validated PendingOrderRequest pendingOrderRequest
     ) {
@@ -29,6 +26,16 @@ public class PendingOrderController {
         return ResponseEntity
                 .status(HttpStatus.CREATED)
                 .body(ApiResponse.success(pendingOrderResponse));
+    }
+
+    @DeleteMapping("/pending-order/{order-id}")
+    public ResponseEntity<ApiResponse<Void>> deletePendingOrder(
+            @PathVariable("order-id") String orderId
+    ) {
+        pendingOrderService.deletePendingOrder(orderId);
+
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(ApiResponse.success(null));
     }
 
 }

--- a/src/main/java/com/jamjam/bookjeok/domains/order/repository/order/pendingorder/PendingOrderRepository.java
+++ b/src/main/java/com/jamjam/bookjeok/domains/order/repository/order/pendingorder/PendingOrderRepository.java
@@ -9,4 +9,6 @@ public interface PendingOrderRepository extends JpaRepository<PendingOrder, Long
 
     Optional<PendingOrder> findPendingOrderByOrderIdAndTotalAmount(String orderId, int totalAmount);
 
+    void deletePendingOrderByOrderId(String orderId);
+
 }

--- a/src/main/java/com/jamjam/bookjeok/domains/order/service/pendingorder/PendingOrderService.java
+++ b/src/main/java/com/jamjam/bookjeok/domains/order/service/pendingorder/PendingOrderService.java
@@ -11,4 +11,6 @@ public interface PendingOrderService {
 
     PendingOrder getPendingOrder(PaymentConfirmRequest paymentConfirmRequest);
 
+    void deletePendingOrder(String orderId);
+
 }

--- a/src/main/java/com/jamjam/bookjeok/domains/order/service/pendingorder/PendingOrderServiceImpl.java
+++ b/src/main/java/com/jamjam/bookjeok/domains/order/service/pendingorder/PendingOrderServiceImpl.java
@@ -44,6 +44,11 @@ public class PendingOrderServiceImpl implements PendingOrderService {
                 .orElseThrow(() -> new PaymentOrderNotFountException("주문 정보가 일치하지 않습니다."));
     }
 
+    @Override
+    public void deletePendingOrder(String orderId) {
+        pendingOrderRepository.deletePendingOrderByOrderId(orderId);
+    }
+
     private List<Book> validateOrderBooks(PendingOrderRequest pendingOrderRequest) {
         return pendingOrderRequest.orderBookItems().stream()
                 .map(orderBookInfo ->

--- a/src/main/java/com/jamjam/bookjeok/domains/payment/service/PaymentServiceImpl.java
+++ b/src/main/java/com/jamjam/bookjeok/domains/payment/service/PaymentServiceImpl.java
@@ -6,7 +6,6 @@ import com.jamjam.bookjeok.domains.order.dto.orderdetail.OrderDetailDTO;
 import com.jamjam.bookjeok.domains.order.dto.pendingorder.request.PendingOrderBookItemsRequest;
 import com.jamjam.bookjeok.domains.order.entity.Order;
 import com.jamjam.bookjeok.domains.order.entity.PendingOrder;
-import com.jamjam.bookjeok.domains.order.repository.order.pendingorder.PendingOrderRepository;
 import com.jamjam.bookjeok.domains.order.service.order.OrderService;
 import com.jamjam.bookjeok.domains.order.service.orderdetail.OrderDetailService;
 import com.jamjam.bookjeok.domains.order.service.pendingorder.PendingOrderService;
@@ -39,7 +38,6 @@ public class PaymentServiceImpl implements PaymentService {
     private final OrderDetailService orderDetailService;
 
     private final BookRepository bookRepository;
-    private final PendingOrderRepository pendingOrderRepository;
     private final PaymentRepository paymentRepository;
 
     @Override
@@ -51,7 +49,7 @@ public class PaymentServiceImpl implements PaymentService {
         orderDetailService.createOrderDetails(orderItems, savedOrder);
 
         savePayment(paymentDTO, savedOrder);
-        pendingOrderRepository.delete(findPendingOrder);
+        pendingOrderService.deletePendingOrder(findPendingOrder.getOrderId());
 
         List<OrderDetailDTO> orderDetails = orderDetailService.findOrderDetailByOrderId(paymentDTO.orderId());
 
@@ -71,8 +69,7 @@ public class PaymentServiceImpl implements PaymentService {
 
             if (stockQuantity < 0) {
                 log.info("stockQuantity = {}", stockQuantity);
-                pendingOrderRepository.delete(findPendingOrder);
-                throw new InsufficientBookStockException("도서 수량이 부족하여 결제를 진행할 수 없습니다.");
+                throw new InsufficientBookStockException("도서 재고 수량이 부족하여 결제를 진행할 수 없습니다.");
             }
 
             findBook.updateStockQuantity(stockQuantity, LocalDateTime.now().withNano(0));

--- a/src/test/java/com/jamjam/bookjeok/domains/order/controller/order/PendingOrderControllerTest.java
+++ b/src/test/java/com/jamjam/bookjeok/domains/order/controller/order/PendingOrderControllerTest.java
@@ -63,7 +63,7 @@ class PendingOrderControllerTest {
                 .orderBookItems(pendingOrderBookItemsRequest)
                 .build();
 
-        mockMvc.perform(post("/api/v1/order/payment")
+        mockMvc.perform(post("/api/v1/pending-order")
                         .contentType(MediaType.APPLICATION_JSON)
                         .accept(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(pendingOrderRequest))
@@ -94,7 +94,7 @@ class PendingOrderControllerTest {
                 .orderBookItems(pendingOrderBookItemsRequest)
                 .build();
 
-        mockMvc.perform(post("/api/v1/order/payment")
+        mockMvc.perform(post("/api/v1/pending-order")
                         .contentType(MediaType.APPLICATION_JSON)
                         .accept(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(pendingOrderRequest))
@@ -123,7 +123,7 @@ class PendingOrderControllerTest {
                 .orderBookItems(pendingOrderBookItemsRequest)
                 .build();
 
-        mockMvc.perform(post("/api/v1/order/payment")
+        mockMvc.perform(post("/api/v1/pending-order")
                         .contentType(MediaType.APPLICATION_JSON)
                         .accept(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(pendingOrderRequest))
@@ -152,7 +152,7 @@ class PendingOrderControllerTest {
                 .orderBookItems(pendingOrderBookItemsRequest)
                 .build();
 
-        mockMvc.perform(post("/api/v1/order/payment")
+        mockMvc.perform(post("/api/v1/pending-order")
                         .contentType(MediaType.APPLICATION_JSON)
                         .accept(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(pendingOrderRequest))
@@ -181,7 +181,7 @@ class PendingOrderControllerTest {
                 .orderBookItems(pendingOrderBookItemsRequest)
                 .build();
 
-        mockMvc.perform(post("/api/v1/order/payment")
+        mockMvc.perform(post("/api/v1/pending-order")
                         .contentType(MediaType.APPLICATION_JSON)
                         .accept(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(pendingOrderRequest))
@@ -210,7 +210,7 @@ class PendingOrderControllerTest {
                 .orderBookItems(pendingOrderBookItemsRequest)
                 .build();
 
-        mockMvc.perform(post("/api/v1/order/payment")
+        mockMvc.perform(post("/api/v1/pending-order")
                         .contentType(MediaType.APPLICATION_JSON)
                         .accept(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(pendingOrderRequest))

--- a/src/test/java/com/jamjam/bookjeok/domains/order/service/pendingorder/PendingOrderServiceImplTest.java
+++ b/src/test/java/com/jamjam/bookjeok/domains/order/service/pendingorder/PendingOrderServiceImplTest.java
@@ -22,6 +22,7 @@ import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
 @Slf4j
 @Transactional
@@ -134,6 +135,28 @@ class PendingOrderServiceImplTest {
         assertThatThrownBy(() -> pendingOrderService.getPendingOrder(paymentConfirmRequest))
                 .isInstanceOf(PaymentOrderNotFountException.class)
                 .hasMessage("주문 정보가 일치하지 않습니다.");
+    }
+
+    @Test
+    @DisplayName("임시 주문 정보를 삭제하는 테스트")
+    void testDeletePendingOrder() {
+        PendingOrderRequest pendingOrderRequest = PendingOrderRequest.builder()
+                .memberUid(1L)
+                .orderBookItems(pendingOrderBookItemsRequest)
+                .build();
+
+        PendingOrderResponse savedPendingOrder = pendingOrderService.createOrder(pendingOrderRequest);
+
+        PaymentConfirmRequest paymentConfirmRequest = PaymentConfirmRequest.builder()
+                .orderId(savedPendingOrder.orderId())
+                .amount(savedPendingOrder.totalAmount())
+                .build();
+
+        PendingOrder pendingOrder = pendingOrderService.getPendingOrder(paymentConfirmRequest);
+
+        log.info("pendingOrder = {}", pendingOrder);
+
+        assertDoesNotThrow(() -> pendingOrderService.deletePendingOrder(pendingOrder.getOrderId()));
     }
 
 }


### PR DESCRIPTION
- 도서 재고 수량이 부족하여 예외가 발생하면, 롤백되어 데이터베이스에 저장된 임시 주문 정보 삭제가 안되는 부분을 수정
- 도서 재고 수량이 부족하여 예외가 발생하면 클라이언트에 예외 메시지와 에러 코드를 반환하고, 클라이언트가 `/pending-order/{order-id}` 엔드포인트로 리다이렉트하여 임시 주문 정보를 삭제하도록 코드를 수정함