### PR TITLE
[FIX] admin인 경우에만 멤버를 검색, 조회할 수 있게 수정 및 controller테스트 수정

### DIFF
--- a/src/main/java/com/jamjam/bookjeok/domains/member/controller/AdminController.java
+++ b/src/main/java/com/jamjam/bookjeok/domains/member/controller/AdminController.java
@@ -9,6 +9,7 @@ import com.jamjam.bookjeok.domains.member.service.AdminService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -22,15 +23,17 @@ public class AdminController {
 
     private final AdminService adminService;
 
-//    @GetMapping("/admin/members")
-//    public ResponseEntity<ApiResponse<MemberListResponse>> getAllMembers(
-//            @Validated PageRequest pageRequest
-//    ){
-//        MemberListResponse response = adminService.getAllMembers(pageRequest);
-//
-//        return ResponseEntity.ok(ApiResponse.success(response));
-//    }
+    @PreAuthorize("hasAuthority('ADMIN')")
+    @GetMapping("/admin/members")
+    public ResponseEntity<ApiResponse<MemberListResponse>> getAllMembers(
+            @Validated PageRequest pageRequest
+    ){
+        MemberListResponse response = adminService.getAllMembers(pageRequest);
 
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    @PreAuthorize("hasAuthority('ADMIN')")
     @GetMapping("/admin/member")
     public ResponseEntity<ApiResponse<MemberDetailResponse>> getMemberByName(
             MemberSearchRequest memberSearchRequest

--- a/src/main/java/com/jamjam/bookjeok/domains/member/controller/MemberQueryController.java
+++ b/src/main/java/com/jamjam/bookjeok/domains/member/controller/MemberQueryController.java
@@ -2,11 +2,9 @@ package com.jamjam.bookjeok.domains.member.controller;
 
 import com.jamjam.bookjeok.common.dto.ApiResponse;
 import com.jamjam.bookjeok.domains.member.dto.response.MemberDetailResponse;
-import com.jamjam.bookjeok.domains.member.dto.response.MemberListResponse;
 import com.jamjam.bookjeok.domains.member.service.MemberQueryService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -27,19 +25,4 @@ public class MemberQueryController {
         MemberDetailResponse response = memberQueryService.getMemberDetail(userDetails.getUsername());
         return ResponseEntity.ok(ApiResponse.success(response));
     }
-
-    // 간단한 URL 패턴보다 복잡한 비즈니스 로직이나 메서드 단위의 세밀한 보안 제어가 필요한 경우
-    // @PreAuthorize : 메소드 호출 전에 조건 평가
-    // @PostAuthorize : 반환 결과에 기반한 후 처리 보안
-    @PreAuthorize("hasAuthority('ADMIN')")
-    @GetMapping("/admin/members")
-    public ResponseEntity<ApiResponse<MemberListResponse>> getMembers() {
-        MemberListResponse response = memberQueryService.getAllMembers();
-        return ResponseEntity.ok(ApiResponse.success(response));
-    }
-
-
-
-
-
 }

--- a/src/test/java/com/jamjam/bookjeok/domains/member/controller/AdminControllerTest.java
+++ b/src/test/java/com/jamjam/bookjeok/domains/member/controller/AdminControllerTest.java
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
@@ -26,6 +27,7 @@ class AdminControllerTest {
     MockMvc mockMvc;
 
     @DisplayName("멤버 전체 조회 테스트")
+    @WithMockUser(authorities = "ADMIN")
     @Test
     void getAllMembersTest() throws Exception {
         mockMvc.perform(get("/api/v1/admin/members"))
@@ -36,8 +38,9 @@ class AdminControllerTest {
                 .andDo(print());
     }
 
-    @Test
     @DisplayName("멤버의 아이디로 멤버를 검색하는 테스트")
+    @WithMockUser(authorities = "ADMIN")
+    @Test
     void getMemberByIdTest() throws Exception {
         String memberId = "user02";
 
@@ -61,6 +64,7 @@ class AdminControllerTest {
     }
 
     @Test
+    @WithMockUser(authorities = "ADMIN")
     @DisplayName("멤버의 닉네임으로 멤버를 검색하는 테스트")
     void getMemberByNicknameTest() throws Exception {
         String nickname = "닉네임02";


### PR DESCRIPTION
## ⭐ 권한 추가, 테스트 수정
Admin 권한 추가 및 테스트 수정

## ✅ 상세 수정 내용
- `MemberQueryController`에 있는 관리자의 멤버 조회 기능 삭제
- `AdminController`에 있는 관리자의 멤버 조회 기능 활성화 후 관리자인 경우에만 접근할 수 있게 변경
- `AdminController` 수정 
  - Admin인 경우에만 접근이 가능하므로 `@WithMockUser`를 이용해 가짜 권한 부여 한 뒤에 테스트 진행